### PR TITLE
Update version of actions/checkout to v4

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -32,7 +32,7 @@ jobs:
             torch-version: "2.2.0"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Summary
This PR updates `actions/checkout` to v4.0.0 in GitHub actions.