### PR TITLE
`audyn.utils.instantiate`

### DIFF
--- a/audyn/criterion/base.py
+++ b/audyn/criterion/base.py
@@ -30,7 +30,7 @@ class MultiCriteria(nn.ModuleDict):
 
     Examples:
 
-        >>> import hydra
+        >>> import audyn
         >>> import torch
         >>> torch.manual_seed(0)
         >>> config = {
@@ -68,7 +68,7 @@ class MultiCriteria(nn.ModuleDict):
         ...         }
         ...     }
         >>> }
-        >>> criterion = hydra.utils.instantiate(config)
+        >>> criterion = audyn.utils.instantiate_criterion(config)
         >>> y = torch.randn((4,))
         >>> t_mse = torch.randn_like(y)
         >>> t_mae = torch.randn_like(y)

--- a/audyn/utils/driver/base.py
+++ b/audyn/utils/driver/base.py
@@ -5,7 +5,6 @@ import warnings
 from logging import Logger
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import hydra
 import matplotlib.pyplot as plt
 import torch
 import torch.nn as nn
@@ -25,6 +24,7 @@ from ...optim.optimizer import (
     MovingAverageWrapper,
     MultiOptimizers,
 )
+from ...utils import instantiate
 from ..alignment import expand_by_duration
 from ..clip_grad import GradClipper
 from ..data import BaseDataLoaders, select_device
@@ -772,9 +772,7 @@ class BaseTrainer(BaseDriver):
 
             if _is_audyn_clip_gradient(clip_gradient_fn):
                 # for backward compatibility
-                self.grad_clipper = hydra.utils.instantiate(
-                    clip_gradient_config, self.model.parameters()
-                )
+                self.grad_clipper = instantiate(clip_gradient_config, self.model.parameters())
                 is_legacy = False
             elif _is_torch_clip_gradient(clip_gradient_fn):
                 is_legacy = True
@@ -783,7 +781,7 @@ class BaseTrainer(BaseDriver):
 
         if is_legacy:
             # for backward compatibility
-            hydra.utils.instantiate(clip_gradient_config, self.model.parameters())
+            instantiate(clip_gradient_config, self.model.parameters())
         else:
             self.grad_clipper.step()
 
@@ -1515,7 +1513,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             duration = transform(duration)
 
                     self.write_duration(
@@ -1533,7 +1531,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             duration = transform(duration)
 
                     self.write_duration(
@@ -1611,7 +1609,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             spectrogram = transform(spectrogram)
 
                     self.write_spectrogram(
@@ -1629,7 +1627,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             spectrogram = transform(spectrogram)
 
                     self.write_spectrogram(
@@ -1681,7 +1679,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             waveform = transform(waveform)
 
                     self.write_waveform(
@@ -1699,7 +1697,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             waveform = transform(waveform)
 
                     self.write_waveform(
@@ -1761,7 +1759,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             waveform = transform(waveform)
 
                     self.write_audio(
@@ -1782,7 +1780,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             waveform = transform(waveform)
 
                     self.write_audio(
@@ -1842,7 +1840,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output:
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             image = transform(image)
 
                     self.write_image(
@@ -1860,7 +1858,7 @@ class BaseTrainer(BaseDriver):
 
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference:
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             image = transform(image)
 
                     self.write_image(
@@ -2078,7 +2076,7 @@ class BaseGenerator(BaseDriver):
                 for idx, waveform in enumerate(named_output[key]):
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             waveform = transform(waveform)
 
                     identifier_mapping = {
@@ -2097,7 +2095,7 @@ class BaseGenerator(BaseDriver):
                 for waveform in named_reference[key]:
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             waveform = transform(waveform)
 
                     identifier_mapping = {
@@ -2211,7 +2209,7 @@ class BaseGenerator(BaseDriver):
                 for idx, image in enumerate(named_output[key]):
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             image = transform(image)
 
                     identifier_mapping = {
@@ -2230,7 +2228,7 @@ class BaseGenerator(BaseDriver):
                 for image in named_reference[key]:
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             image = transform(image)
 
                     identifier_mapping = {

--- a/audyn/utils/driver/gan.py
+++ b/audyn/utils/driver/gan.py
@@ -3,7 +3,6 @@ import os
 import warnings
 from typing import Dict, Iterable, Optional, Union
 
-import hydra
 import torch
 import torch.nn as nn
 from omegaconf import DictConfig, OmegaConf
@@ -15,6 +14,7 @@ from ...metrics import MeanMetric
 from ...models.gan import BaseGAN
 from ...optim.lr_scheduler import GANLRScheduler
 from ...optim.optimizer import GANOptimizer, MovingAverageWrapper, MultiOptimizers
+from ...utils import instantiate
 from ..clip_grad import GANGradClipper
 from ..data import BaseDataLoaders
 from ..hydra.utils import instantiate_grad_clipper
@@ -794,9 +794,7 @@ class GANTrainer(BaseTrainer):
             if _is_audyn_clip_gradient(clip_gradient_fn):
                 # for backward compatibility
                 # clip all parameters
-                self.grad_clipper = hydra.utils.instantiate(
-                    clip_gradient_config, self.model.parameters()
-                )
+                self.grad_clipper = instantiate(clip_gradient_config, self.model.parameters())
                 is_legacy = False
             elif clip_gradient_fn is GANGradClipper:
                 # for backward compatibility
@@ -819,7 +817,7 @@ class GANTrainer(BaseTrainer):
         if is_legacy:
             # for backward compatibility
             parameters = parameters_or_name
-            hydra.utils.instantiate(clip_gradient_config, parameters)
+            instantiate(clip_gradient_config, parameters)
         else:
             if isinstance(parameters_or_name, str):
                 name = parameters_or_name

--- a/audyn/utils/hydra/utils.py
+++ b/audyn/utils/hydra/utils.py
@@ -101,14 +101,18 @@ def instantiate(config: Any, *args, **kwargs) -> Any:
 
 def instantiate_model(
     config_or_path: Union[str, DictConfig],
+    *args,
     load_weights: Optional[bool] = None,
+    **kwargs,
 ) -> nn.Module:
     """Instantiate model.
 
     Args:
         config_or_path (str or DictConfig): Config of model.
+        args: Positional arguments given to ``instantiate``.
         load_weights (bool, optional): If ``True``, model loads pretrained weights.
             Default: ``False``.
+        kwargs: Keyword arguments given to ``instantiate``.
 
     Returns:
         nn.Module: Constructed model.
@@ -123,7 +127,7 @@ def instantiate_model(
         resolved_config: Dict[str, Any] = state_dict["resolved_config"]
         model_config: Dict[str, Any] = resolved_config["model"]
         model_config = OmegaConf.create(model_config)
-        model: nn.Module = instantiate(model_config)
+        model: nn.Module = instantiate(model_config, *args, **kwargs)
 
         if load_weights:
             model.load_state_dict(state_dict["model"])
@@ -135,7 +139,7 @@ def instantiate_model(
             )
 
         model_config = config_or_path
-        model: nn.Module = instantiate(model_config)
+        model: nn.Module = instantiate(model_config, *args, **kwargs)
     else:
         raise NotImplementedError(f"{type(config_or_path)} is not supported.")
 

--- a/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/save_prior.py
+++ b/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/save_prior.py
@@ -1,14 +1,13 @@
 import functools
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 import torch.nn.functional as F
 from omegaconf import DictConfig
 from utils.driver import PriorSaver
 
 import audyn
-from audyn.utils import instantiate_model, setup_system
+from audyn.utils import instantiate, instantiate_model, setup_system
 from audyn.utils.data import default_collate_fn, take_log_features
 from audyn.utils.model import set_device
 
@@ -21,8 +20,8 @@ def main(config: DictConfig) -> None:
     n_frames = config.data.audio.length // config.data.melspectrogram.hop_length
     n_frames = n_frames - (n_frames % down_scale)
 
-    dataset = hydra.utils.instantiate(config.train.dataset)
-    loader = hydra.utils.instantiate(
+    dataset = instantiate(config.train.dataset)
+    loader = instantiate(
         config.train.dataloader,
         dataset,
         collate_fn=functools.partial(collate_fn, n_frames=n_frames),

--- a/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/test.py
+++ b/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/test.py
@@ -1,14 +1,13 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
 from utils.driver import Generator
 from utils.utils import instantiate_cascade_model
 
 import audyn
-from audyn.utils import setup_system
+from audyn.utils import instantiate, setup_system
 from audyn.utils.data import default_collate_fn
 from audyn.utils.model import set_device
 
@@ -23,8 +22,8 @@ def main(config: DictConfig) -> None:
     vqvae_config = OmegaConf.create(vqvae_state_dict["resolved_config"])
     codebook_size = vqvae_config.data.codebook.size
 
-    test_dataset = hydra.utils.instantiate(config.test.dataset.test)
-    test_loader = hydra.utils.instantiate(
+    test_dataset = instantiate(config.test.dataset.test)
+    test_loader = instantiate(
         config.test.dataloader.test,
         test_dataset,
         collate_fn=functools.partial(

--- a/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/train_hifigan.py
+++ b/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/train_hifigan.py
@@ -1,7 +1,6 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
@@ -10,7 +9,15 @@ from audyn.criterion.gan import GANCriterion
 from audyn.models.gan import BaseGAN
 from audyn.optim.lr_scheduler import GANLRScheduler
 from audyn.optim.optimizer import GANOptimizer
-from audyn.utils import instantiate_grad_clipper, instantiate_model, setup_system
+from audyn.utils import (
+    instantiate,
+    instantiate_criterion,
+    instantiate_grad_clipper,
+    instantiate_lr_scheduler,
+    instantiate_model,
+    instantiate_optimizer,
+    setup_system,
+)
 from audyn.utils.clip_grad import GANGradClipper
 from audyn.utils.data import (
     BaseDataLoaders,
@@ -26,10 +33,10 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -38,7 +45,7 @@ def main(config: DictConfig) -> None:
             random_slice=True,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(
@@ -56,16 +63,14 @@ def main(config: DictConfig) -> None:
         is_distributed=config.system.distributed.enable,
         ddp_kwargs=config.train.ddp_kwargs,
     )
-    generator_optimizer = hydra.utils.instantiate(
-        config.optimizer.generator, generator.parameters()
-    )
-    generator_lr_scheduler = hydra.utils.instantiate(
+    generator_optimizer = instantiate_optimizer(config.optimizer.generator, generator.parameters())
+    generator_lr_scheduler = instantiate_lr_scheduler(
         config.lr_scheduler.generator, generator_optimizer
     )
     generator_grad_clipper = instantiate_grad_clipper(
         config.train.clip_gradient.generator, generator.parameters()
     )
-    generator_criterion = hydra.utils.instantiate(config.criterion.generator)
+    generator_criterion = instantiate_criterion(config.criterion.generator)
     generator_criterion = set_device(
         generator_criterion,
         accelerator=config.system.accelerator,
@@ -80,16 +85,16 @@ def main(config: DictConfig) -> None:
         is_distributed=config.system.distributed.enable,
         ddp_kwargs=config.train.ddp_kwargs,
     )
-    discriminator_optimizer = hydra.utils.instantiate(
+    discriminator_optimizer = instantiate_optimizer(
         config.optimizer.discriminator, discriminator.parameters()
     )
-    discriminator_lr_scheduler = hydra.utils.instantiate(
+    discriminator_lr_scheduler = instantiate_lr_scheduler(
         config.lr_scheduler.discriminator, discriminator_optimizer
     )
     discriminator_grad_clipper = instantiate_grad_clipper(
         config.train.clip_gradient.discriminator, discriminator.parameters()
     )
-    discriminator_criterion = hydra.utils.instantiate(config.criterion.discriminator)
+    discriminator_criterion = instantiate_criterion(config.criterion.discriminator)
     discriminator_criterion = set_device(
         discriminator_criterion,
         accelerator=config.system.accelerator,

--- a/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/train_pixelsnail.py
+++ b/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/train_pixelsnail.py
@@ -1,12 +1,12 @@
 import functools
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -23,12 +23,12 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     codebook_size = config.data.codebook.size
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -36,7 +36,7 @@ def main(config: DictConfig) -> None:
             codebook_size=codebook_size,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/train_vqvae.py
+++ b/recipes/DCASE2023FoleySoundSynthesis/Baseline/local/train_vqvae.py
@@ -1,13 +1,13 @@
 import functools
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 import torch.nn.functional as F
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -24,8 +24,8 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     codebook_size = config.data.codebook.size
     down_scale = config.model.encoder.stride**config.model.encoder.num_stacks
@@ -35,7 +35,7 @@ def main(config: DictConfig) -> None:
     else:
         num_layers = None
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -45,7 +45,7 @@ def main(config: DictConfig) -> None:
             num_layers=num_layers,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/DCASE2023FoleySoundSynthesis/Baseline/utils/utils.py
+++ b/recipes/DCASE2023FoleySoundSynthesis/Baseline/utils/utils.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, Optional
 
-import hydra
 import torch
 import torch.nn as nn
 from omegaconf import DictConfig, OmegaConf
 from utils.models.cascade import BaselineModel
+
+from audyn.utils import instantiate_model
 
 
 def instantiate_cascade_model(
@@ -40,21 +41,21 @@ def instantiate_cascade_model(
     pixelsnail_resolved_config: Dict[str, Any] = pixelsnail_state_dict["resolved_config"]
     pixelsnail_model_config: Dict[str, Any] = pixelsnail_resolved_config["model"]
     pixelsnail_model_config = OmegaConf.create(pixelsnail_model_config)
-    pixelsnail: nn.Module = hydra.utils.instantiate(pixelsnail_model_config)
+    pixelsnail: nn.Module = instantiate_model(pixelsnail_model_config)
 
     # VQVAE
     vqvae_resolved_config: Dict[str, Any] = vqvae_state_dict["resolved_config"]
     vqvae_model_config: Dict[str, Any] = vqvae_resolved_config["model"]
     vqvae_model_config = OmegaConf.create(vqvae_model_config)
-    vqvae: nn.Module = hydra.utils.instantiate(vqvae_model_config)
+    vqvae: nn.Module = instantiate_model(vqvae_model_config)
 
     # HiFi-GAN
     hifigan_resolved_config: Dict[str, Any] = hifigan_state_dict["resolved_config"]
     hifigan_model_config: Dict[str, Any] = hifigan_resolved_config["model"]
     hifigan_model_config = OmegaConf.create(hifigan_model_config)
-    hifigan_generator: nn.Module = hydra.utils.instantiate(hifigan_model_config.generator)
+    hifigan_generator: nn.Module = instantiate_model(hifigan_model_config.generator)
 
-    model: BaselineModel = hydra.utils.instantiate(
+    model: BaselineModel = instantiate_model(
         config,
         pixelsnail=pixelsnail,
         vqvae=vqvae,

--- a/recipes/LJSpeech-tiny/SoundStream/local/save_quantized_features.py
+++ b/recipes/LJSpeech-tiny/SoundStream/local/save_quantized_features.py
@@ -1,13 +1,12 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 from omegaconf import DictConfig
 from utils.driver import QuantizedFeatureSaver
 
 import audyn
-from audyn.utils import instantiate_gan_generator, setup_system
+from audyn.utils import instantiate, instantiate_gan_generator, setup_system
 from audyn.utils.data import default_collate_fn, slice_feautures
 from audyn.utils.model import set_device
 
@@ -16,9 +15,9 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    dataset = hydra.utils.instantiate(config.train.dataset)
+    dataset = instantiate(config.train.dataset)
 
-    loader = hydra.utils.instantiate(
+    loader = instantiate(
         config.train.dataloader,
         dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech-tiny/SoundStream/local/train_tts.py
+++ b/recipes/LJSpeech-tiny/SoundStream/local/train_tts.py
@@ -1,13 +1,13 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 import torch.nn.functional as F
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -24,15 +24,15 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data),

--- a/recipes/LJSpeech/FastSpeech+WaveNet/local/test.py
+++ b/recipes/LJSpeech/FastSpeech+WaveNet/local/test.py
@@ -1,13 +1,12 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 import torchaudio.functional as aF
 from omegaconf import DictConfig
 
 import audyn
-from audyn.utils import instantiate_cascade_text_to_wave, setup_system
+from audyn.utils import instantiate, instantiate_cascade_text_to_wave, setup_system
 from audyn.utils.data import default_collate_fn
 from audyn.utils.driver import CascadeTextToWaveGenerator
 from audyn.utils.model import set_device
@@ -17,9 +16,9 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    test_dataset = hydra.utils.instantiate(config.test.dataset.test)
+    test_dataset = instantiate(config.test.dataset.test)
 
-    test_loader = hydra.utils.instantiate(
+    test_loader = instantiate(
         config.test.dataloader.test,
         test_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data),

--- a/recipes/LJSpeech/FastSpeech/local/train.py
+++ b/recipes/LJSpeech/FastSpeech/local/train.py
@@ -1,11 +1,12 @@
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
+    instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
     instantiate_model,
@@ -21,15 +22,15 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=collate_fn,
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=collate_fn,
@@ -46,7 +47,7 @@ def main(config: DictConfig) -> None:
     optimizer = instantiate_optimizer(config.optimizer, model)
     lr_scheduler = instantiate_lr_scheduler(config.lr_scheduler, optimizer)
     grad_clipper = instantiate_grad_clipper(config.train.clip_gradient, model.parameters())
-    criterion = hydra.utils.instantiate(config.criterion)
+    criterion = instantiate_criterion(config.criterion)
     criterion = set_device(
         criterion,
         accelerator=config.system.accelerator,

--- a/recipes/LJSpeech/GlowTTS/local/save_features.py
+++ b/recipes/LJSpeech/GlowTTS/local/save_features.py
@@ -2,7 +2,6 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import Dict, List
 
-import hydra
 import torch
 import torchaudio
 import torchaudio.functional as aF
@@ -11,6 +10,7 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 import audyn
+from audyn.utils import instantiate
 from audyn.utils.data.cmudict import BOS_SYMBOL, BREAK_SYMBOLS, EOS_SYMBOL
 from audyn.utils.text import TextPreprocessor, load_text
 
@@ -28,7 +28,7 @@ def main(config: DictConfig) -> None:
     assert feature_dir is not None, "Specify preprocess.feature_dir."
 
     melspectrogram_transform = aT.MelSpectrogram(**config.data.melspectrogram)
-    text_preprocessor = hydra.utils.instantiate(config.data.text.preprocessor)
+    text_preprocessor = instantiate(config.data.text.preprocessor)
 
     os.makedirs(feature_dir, exist_ok=True)
 

--- a/recipes/LJSpeech/GlowTTS/local/train.py
+++ b/recipes/LJSpeech/GlowTTS/local/train.py
@@ -1,11 +1,11 @@
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -22,15 +22,15 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=collate_fn,
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=collate_fn,

--- a/recipes/LJSpeech/HiFiGAN/local/train.py
+++ b/recipes/LJSpeech/HiFiGAN/local/train.py
@@ -1,7 +1,6 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
@@ -11,9 +10,13 @@ from audyn.models.gan import BaseGAN
 from audyn.optim.lr_scheduler import GANLRScheduler
 from audyn.optim.optimizer import GANOptimizer
 from audyn.utils import (
+    instantiate,
+    instantiate_criterion,
     instantiate_gan_discriminator,
     instantiate_gan_generator,
     instantiate_grad_clipper,
+    instantiate_lr_scheduler,
+    instantiate_optimizer,
     setup_system,
 )
 from audyn.utils.clip_grad import GANGradClipper
@@ -31,10 +34,10 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -43,7 +46,7 @@ def main(config: DictConfig) -> None:
             random_slice=True,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(
@@ -61,16 +64,14 @@ def main(config: DictConfig) -> None:
         is_distributed=config.system.distributed.enable,
         ddp_kwargs=config.train.ddp_kwargs,
     )
-    generator_optimizer = hydra.utils.instantiate(
-        config.optimizer.generator, generator.parameters()
-    )
-    generator_lr_scheduler = hydra.utils.instantiate(
+    generator_optimizer = instantiate_optimizer(config.optimizer.generator, generator.parameters())
+    generator_lr_scheduler = instantiate_lr_scheduler(
         config.lr_scheduler.generator, generator_optimizer
     )
     generator_grad_clipper = instantiate_grad_clipper(
         config.train.clip_gradient.generator, generator.parameters()
     )
-    generator_criterion = hydra.utils.instantiate(config.criterion.generator)
+    generator_criterion = instantiate_criterion(config.criterion.generator)
     generator_criterion = set_device(
         generator_criterion,
         accelerator=config.system.accelerator,
@@ -85,16 +86,16 @@ def main(config: DictConfig) -> None:
         is_distributed=config.system.distributed.enable,
         ddp_kwargs=config.train.ddp_kwargs,
     )
-    discriminator_optimizer = hydra.utils.instantiate(
+    discriminator_optimizer = instantiate_optimizer(
         config.optimizer.discriminator, discriminator.parameters()
     )
-    discriminator_lr_scheduler = hydra.utils.instantiate(
+    discriminator_lr_scheduler = instantiate_lr_scheduler(
         config.lr_scheduler.discriminator, discriminator_optimizer
     )
     discriminator_grad_clipper = instantiate_grad_clipper(
         config.train.clip_gradient.discriminator, discriminator.parameters()
     )
-    discriminator_criterion = hydra.utils.instantiate(config.criterion.discriminator)
+    discriminator_criterion = instantiate_criterion(config.criterion.discriminator)
     discriminator_criterion = set_device(
         discriminator_criterion,
         accelerator=config.system.accelerator,

--- a/recipes/LJSpeech/PixelCNN+VQVAE/local/save_prior.py
+++ b/recipes/LJSpeech/PixelCNN+VQVAE/local/save_prior.py
@@ -1,12 +1,11 @@
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 from utils.driver import PriorSaver
 
 import audyn
-from audyn.utils import instantiate_model, setup_system
+from audyn.utils import instantiate, instantiate_model, setup_system
 from audyn.utils.data import default_collate_fn, take_log_features
 from audyn.utils.model import set_device
 
@@ -15,8 +14,8 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    dataset = hydra.utils.instantiate(config.train.dataset)
-    loader = hydra.utils.instantiate(
+    dataset = instantiate(config.train.dataset)
+    loader = instantiate(
         config.train.dataloader,
         dataset,
         collate_fn=collate_fn,

--- a/recipes/LJSpeech/PixelCNN+VQVAE/local/test.py
+++ b/recipes/LJSpeech/PixelCNN+VQVAE/local/test.py
@@ -1,14 +1,13 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
 from utils.driver import Generator
 from utils.utils import instantiate_cascade_model
 
 import audyn
-from audyn.utils import setup_system
+from audyn.utils import instantiate, setup_system
 from audyn.utils.data import default_collate_fn, slice_feautures
 from audyn.utils.model import set_device
 
@@ -24,8 +23,8 @@ def main(config: DictConfig) -> None:
     codebook_size = config.data.codebook.size
     down_scale = vqvae_config.model.encoder.stride**vqvae_config.model.encoder.num_stacks
 
-    test_dataset = hydra.utils.instantiate(config.test.dataset.test)
-    test_loader = hydra.utils.instantiate(
+    test_dataset = instantiate(config.test.dataset.test)
+    test_loader = instantiate(
         config.test.dataloader.test,
         test_dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/PixelCNN+VQVAE/local/train_pixelcnn.py
+++ b/recipes/LJSpeech/PixelCNN+VQVAE/local/train_pixelcnn.py
@@ -1,12 +1,12 @@
 import functools
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -23,12 +23,12 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     codebook_size = config.data.codebook.size
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -38,7 +38,7 @@ def main(config: DictConfig) -> None:
             random_slice=True,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/PixelCNN+VQVAE/local/train_vqvae.py
+++ b/recipes/LJSpeech/PixelCNN+VQVAE/local/train_vqvae.py
@@ -1,12 +1,12 @@
 import functools
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -28,13 +28,13 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     codebook_size = config.data.codebook.size
     down_scale = config.model.encoder.stride**config.model.encoder.num_stacks
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -45,7 +45,7 @@ def main(config: DictConfig) -> None:
             random_slice=True,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/SoundStream/local/save_features.py
+++ b/recipes/LJSpeech/SoundStream/local/save_features.py
@@ -2,7 +2,6 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import Optional
 
-import hydra
 import torch
 import torchaudio
 import torchaudio.functional as aF
@@ -11,6 +10,7 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 import audyn
+from audyn.utils import instantiate
 from audyn.utils.text import TextPreprocessor, load_text
 
 
@@ -31,7 +31,7 @@ def main(config: DictConfig) -> None:
     bos_token = config.data.text.bos_token
     eos_token = config.data.text.eos_token
 
-    text_preprocessor = hydra.utils.instantiate(config.data.text.preprocessor)
+    text_preprocessor = instantiate(config.data.text.preprocessor)
 
     os.makedirs(feature_dir, exist_ok=True)
 

--- a/recipes/LJSpeech/SoundStream/local/save_quantized_features.py
+++ b/recipes/LJSpeech/SoundStream/local/save_quantized_features.py
@@ -1,13 +1,12 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 from omegaconf import DictConfig
 from utils.driver import QuantizedFeatureSaver
 
 import audyn
-from audyn.utils import instantiate_gan_generator, setup_system
+from audyn.utils import instantiate, instantiate_gan_generator, setup_system
 from audyn.utils.data import default_collate_fn
 from audyn.utils.model import set_device
 
@@ -16,9 +15,9 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    dataset = hydra.utils.instantiate(config.train.dataset)
+    dataset = instantiate(config.train.dataset)
 
-    loader = hydra.utils.instantiate(
+    loader = instantiate(
         config.train.dataloader,
         dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/SoundStream/local/test_reconstruction.py
+++ b/recipes/LJSpeech/SoundStream/local/test_reconstruction.py
@@ -1,13 +1,17 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.models.gan import BaseGAN
-from audyn.utils import instantiate_gan_discriminator, instantiate_gan_generator, setup_system
+from audyn.utils import (
+    instantiate,
+    instantiate_gan_discriminator,
+    instantiate_gan_generator,
+    setup_system,
+)
 from audyn.utils.data import default_collate_fn
 from audyn.utils.driver import GANGenerator
 from audyn.utils.model import set_device
@@ -17,9 +21,9 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    test_dataset = hydra.utils.instantiate(config.test.dataset.test)
+    test_dataset = instantiate(config.test.dataset.test)
 
-    test_loader = hydra.utils.instantiate(
+    test_loader = instantiate(
         config.test.dataloader.test,
         test_dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/SoundStream/local/test_tts.py
+++ b/recipes/LJSpeech/SoundStream/local/test_tts.py
@@ -1,12 +1,11 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
-from audyn.utils import instantiate_cascade_text_to_wave, setup_system
+from audyn.utils import instantiate, instantiate_cascade_text_to_wave, setup_system
 from audyn.utils.data import default_collate_fn
 from audyn.utils.driver import CascadeTextToWaveGenerator
 from audyn.utils.model import set_device, unwrap
@@ -30,8 +29,8 @@ def main(config: DictConfig) -> None:
     unwrapped_model = unwrap(model)
     down_scale = unwrapped_model.down_scale
 
-    test_dataset = hydra.utils.instantiate(config.test.dataset.test)
-    test_loader = hydra.utils.instantiate(
+    test_dataset = instantiate(config.test.dataset.test)
+    test_loader = instantiate(
         config.test.dataloader.test,
         test_dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/SoundStream/local/train.py
+++ b/recipes/LJSpeech/SoundStream/local/train.py
@@ -1,7 +1,6 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
@@ -11,6 +10,7 @@ from audyn.models.gan import BaseGAN
 from audyn.optim.lr_scheduler import GANLRScheduler
 from audyn.optim.optimizer import GANOptimizer
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_gan_discriminator,
     instantiate_gan_generator,
@@ -29,8 +29,8 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     down_scale = 1
 
@@ -39,7 +39,7 @@ def main(config: DictConfig) -> None:
 
     num_stages = config.model.generator.num_stages
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -50,7 +50,7 @@ def main(config: DictConfig) -> None:
             random_slice=True,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/LJSpeech/SoundStream/local/train_tts.py
+++ b/recipes/LJSpeech/SoundStream/local/train_tts.py
@@ -1,13 +1,13 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 import torch.nn.functional as F
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -24,15 +24,15 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data),

--- a/recipes/LJSpeech/WaveGlow/local/train.py
+++ b/recipes/LJSpeech/WaveGlow/local/train.py
@@ -1,12 +1,13 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
+    instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
     instantiate_model,
@@ -28,10 +29,10 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -41,7 +42,7 @@ def main(config: DictConfig) -> None:
             std=config.data.noise_std.train,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(
@@ -63,7 +64,7 @@ def main(config: DictConfig) -> None:
     optimizer = instantiate_optimizer(config.optimizer, model)
     lr_scheduler = instantiate_lr_scheduler(config.lr_scheduler, optimizer)
     grad_clipper = instantiate_grad_clipper(config.train.clip_gradient, model.parameters())
-    criterion = hydra.utils.instantiate(config.criterion)
+    criterion = instantiate_criterion(config.criterion)
     criterion = set_device(
         criterion,
         accelerator=config.system.accelerator,

--- a/recipes/LJSpeech/WaveNet/local/train.py
+++ b/recipes/LJSpeech/WaveNet/local/train.py
@@ -1,13 +1,14 @@
 import functools
 from typing import Any, Dict, List
 
-import hydra
 import torch
 import torchaudio.functional as aF
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
+    instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
     instantiate_model,
@@ -28,15 +29,15 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data, random_slice=True),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(collate_fn, data_config=config.data, random_slice=False),
@@ -53,7 +54,7 @@ def main(config: DictConfig) -> None:
     optimizer = instantiate_optimizer(config.optimizer, model)
     lr_scheduler = instantiate_lr_scheduler(config.lr_scheduler, optimizer)
     grad_clipper = instantiate_grad_clipper(config.train.clip_gradient, model.parameters())
-    criterion = hydra.utils.instantiate(config.criterion)
+    criterion = instantiate_criterion(config.criterion)
     criterion = set_device(
         criterion,
         accelerator=config.system.accelerator,

--- a/recipes/LJSpeech/_common/local/normalize_text.py
+++ b/recipes/LJSpeech/_common/local/normalize_text.py
@@ -2,11 +2,11 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import Tuple
 
-import hydra
 from omegaconf import DictConfig
 from tqdm import tqdm
 
 import audyn
+from audyn.utils import instantiate
 from audyn.utils.text import TextPreprocessor
 
 
@@ -16,7 +16,7 @@ def main(config: DictConfig) -> None:
     text_dir = config.preprocess.text_dir
     max_workers = config.preprocess.max_workers
 
-    text_preprocessor = hydra.utils.instantiate(config.data.text.preprocessor)
+    text_preprocessor = instantiate(config.data.text.preprocessor)
 
     with open(metadata_path) as f:
         data = []

--- a/recipes/MNIST/PixelCNN+VQVAE/local/save_prior.py
+++ b/recipes/MNIST/PixelCNN+VQVAE/local/save_prior.py
@@ -1,9 +1,8 @@
-import hydra
 from omegaconf import DictConfig
 from utils.driver import PriorSaver
 
 import audyn
-from audyn.utils import instantiate_model, setup_system
+from audyn.utils import instantiate, instantiate_model, setup_system
 from audyn.utils.model import set_device
 
 
@@ -11,8 +10,8 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    dataset = hydra.utils.instantiate(config.train.dataset)
-    loader = hydra.utils.instantiate(config.train.dataloader, dataset)
+    dataset = instantiate(config.train.dataset)
+    loader = instantiate(config.train.dataloader, dataset)
 
     model = instantiate_model(config.model)
     model = set_device(

--- a/recipes/MNIST/PixelCNN+VQVAE/local/test.py
+++ b/recipes/MNIST/PixelCNN+VQVAE/local/test.py
@@ -1,14 +1,13 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
 from utils.driver import Generator
 from utils.utils import instantiate_cascade_model
 
 import audyn
-from audyn.utils import setup_system
+from audyn.utils import instantiate, setup_system
 from audyn.utils.data import default_collate_fn
 from audyn.utils.model import set_device
 
@@ -24,8 +23,8 @@ def main(config: DictConfig) -> None:
     codebook_size = config.data.codebook.size
     down_scale = vqvae_config.model.encoder.stride**vqvae_config.model.encoder.num_layers
 
-    test_dataset = hydra.utils.instantiate(config.test.dataset.test)
-    test_loader = hydra.utils.instantiate(
+    test_dataset = instantiate(config.test.dataset.test)
+    test_loader = instantiate(
         config.test.dataloader.test,
         test_dataset,
         collate_fn=functools.partial(

--- a/recipes/MNIST/PixelCNN+VQVAE/local/train_pixelcnn.py
+++ b/recipes/MNIST/PixelCNN+VQVAE/local/train_pixelcnn.py
@@ -1,12 +1,12 @@
 import functools
 from typing import Any, Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_lr_scheduler,
     instantiate_model,
@@ -22,12 +22,12 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     codebook_size = config.data.codebook.size
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -35,7 +35,7 @@ def main(config: DictConfig) -> None:
             codebook_size=codebook_size,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/MNIST/PixelCNN+VQVAE/local/train_vqvae.py
+++ b/recipes/MNIST/PixelCNN+VQVAE/local/train_vqvae.py
@@ -1,12 +1,12 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_lr_scheduler,
     instantiate_model,
@@ -22,13 +22,13 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
     codebook_size = config.data.codebook.size
     down_scale = config.model.encoder.stride**config.model.encoder.num_layers
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -37,7 +37,7 @@ def main(config: DictConfig) -> None:
             down_scale=down_scale,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/MNIST/PixelCNN+VQVAE/utils/driver.py
+++ b/recipes/MNIST/PixelCNN+VQVAE/utils/driver.py
@@ -1,7 +1,6 @@
 import os
 from typing import Dict, List
 
-import hydra
 import matplotlib.pyplot as plt
 import torch
 import torch.nn as nn
@@ -18,6 +17,7 @@ try:
 except ImportError:
     IS_TQDM_AVAILABLE = False
 
+from audyn.utils import instantiate
 from audyn.utils.driver import BaseGenerator
 from audyn.utils.driver._decorator import run_only_master_rank
 from audyn.utils.driver.base import BaseDriver
@@ -230,7 +230,7 @@ class Generator(BaseGenerator):
                 for idx, image in enumerate(named_output[key]):
                     if transforms is not None and transforms.output is not None:
                         if key in transforms.output.keys():
-                            transform = hydra.utils.instantiate(transforms.output[key])
+                            transform = instantiate(transforms.output[key])
                             image = transform(image)
 
                     identifier_mapping = {
@@ -249,7 +249,7 @@ class Generator(BaseGenerator):
                 for image in named_reference[key]:
                     if transforms is not None and transforms.reference is not None:
                         if key in transforms.reference.keys():
-                            transform = hydra.utils.instantiate(transforms.reference[key])
+                            transform = instantiate(transforms.reference[key])
                             image = transform(image)
 
                     identifier_mapping = {

--- a/recipes/MNIST/PixelCNN+VQVAE/utils/utils.py
+++ b/recipes/MNIST/PixelCNN+VQVAE/utils/utils.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, Optional
 
-import hydra
 import torch
 import torch.nn as nn
 from omegaconf import DictConfig, OmegaConf
 from utils.models.cascade import PixelCNNVQVAE
+
+from audyn.utils import instantiate_model
 
 
 def instantiate_cascade_model(
@@ -37,15 +38,15 @@ def instantiate_cascade_model(
     pixelcnn_resolved_config: Dict[str, Any] = pixelcnn_state_dict["resolved_config"]
     pixelcnn_model_config: Dict[str, Any] = pixelcnn_resolved_config["model"]
     pixelcnn_model_config = OmegaConf.create(pixelcnn_model_config)
-    pixelcnn: nn.Module = hydra.utils.instantiate(pixelcnn_model_config)
+    pixelcnn: nn.Module = instantiate_model(pixelcnn_model_config)
 
     # VQVAE
     vqvae_resolved_config: Dict[str, Any] = vqvae_state_dict["resolved_config"]
     vqvae_model_config: Dict[str, Any] = vqvae_resolved_config["model"]
     vqvae_model_config = OmegaConf.create(vqvae_model_config)
-    vqvae: nn.Module = hydra.utils.instantiate(vqvae_model_config)
+    vqvae: nn.Module = instantiate_model(vqvae_model_config)
 
-    model: PixelCNNVQVAE = hydra.utils.instantiate(
+    model: PixelCNNVQVAE = instantiate_model(
         config,
         pixelcnn=pixelcnn,
         vqvae=vqvae,

--- a/recipes/UrbanSound8K/HiFiGAN/local/train.py
+++ b/recipes/UrbanSound8K/HiFiGAN/local/train.py
@@ -1,7 +1,6 @@
 import functools
 from typing import Dict, Iterable, List, Optional
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
@@ -11,6 +10,7 @@ from audyn.models.gan import BaseGAN
 from audyn.optim.lr_scheduler import GANLRScheduler
 from audyn.optim.optimizer import GANOptimizer
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_gan_discriminator,
     instantiate_gan_generator,
@@ -34,10 +34,10 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=functools.partial(
@@ -46,7 +46,7 @@ def main(config: DictConfig) -> None:
             random_slice=True,
         ),
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=functools.partial(

--- a/recipes/_common/local/train_text_to_feat.py
+++ b/recipes/_common/local/train_text_to_feat.py
@@ -1,8 +1,8 @@
-import hydra
 from omegaconf import DictConfig
 
 import audyn
 from audyn.utils import (
+    instantiate,
     instantiate_criterion,
     instantiate_grad_clipper,
     instantiate_lr_scheduler,
@@ -19,15 +19,15 @@ from audyn.utils.model import set_device
 def main(config: DictConfig) -> None:
     setup_system(config)
 
-    train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-    validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+    train_dataset = instantiate(config.train.dataset.train)
+    validation_dataset = instantiate(config.train.dataset.validation)
 
-    train_loader = hydra.utils.instantiate(
+    train_loader = instantiate(
         config.train.dataloader.train,
         train_dataset,
         collate_fn=default_collate_fn,
     )
-    validation_loader = hydra.utils.instantiate(
+    validation_loader = instantiate(
         config.train.dataloader.validation,
         validation_dataset,
         collate_fn=default_collate_fn,

--- a/tests/package/models/test_text_to_wave.py
+++ b/tests/package/models/test_text_to_wave.py
@@ -1,8 +1,9 @@
 import os
 
-import hydra
 import torch
 from omegaconf import OmegaConf
+
+from audyn.utils import instantiate_model
 
 conf_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "conf")
 conf_dir = os.path.join(conf_root, "text_to_wave")
@@ -37,7 +38,7 @@ def test_fastspeech_wavenet():
         dtype=torch.float,
     )
 
-    model = hydra.utils.instantiate(config)
+    model = instantiate_model(config)
 
     output, melspectrogram, log_duration = model.inference(input, discrete_initial_state)
 
@@ -77,7 +78,7 @@ def test_fastspeech_waveglow():
     input = torch.randint(0, vocab_size, (batch_size, max_length))
     input = input.masked_fill(src_key_padding_mask, 0)
 
-    model = hydra.utils.instantiate(config)
+    model = instantiate_model(config)
 
     output, melspectrogram, log_duration = model.inference(input)
 

--- a/tests/package/utils/test_driver.py
+++ b/tests/package/utils/test_driver.py
@@ -23,6 +23,7 @@ from audyn.optim.lr_scheduler import GANLRScheduler
 from audyn.optim.optimizer import GANOptimizer
 from audyn.utils import (
     convert_dataloader_to_ddp_if_possible,
+    instantiate,
     instantiate_cascade_text_to_wave,
     instantiate_criterion,
     instantiate_grad_clipper,
@@ -97,19 +98,19 @@ def test_base_drivers(monkeypatch: MonkeyPatch, use_ema: bool) -> None:
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
-        test_dataset = hydra.utils.instantiate(config.test.dataset.test)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
+        test_dataset = instantiate(config.test.dataset.test)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
         )
-        test_loader = hydra.utils.instantiate(
+        test_loader = instantiate(
             config.test.dataloader.test,
             test_dataset,
         )
@@ -294,14 +295,14 @@ def test_base_trainer_ddp(monkeypatch: MonkeyPatch) -> None:
             == "audyn.utils.data.dataloader.DistributedDataLoader"
         )
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
-        train_loader = hydra.utils.instantiate(
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -397,15 +398,15 @@ def test_text_to_feat_trainer(
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -487,15 +488,15 @@ def test_text_to_feat_with_pretrained_feat_to_wave_trainer(monkeypatch: MonkeyPa
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -555,15 +556,15 @@ def test_text_to_feat_with_pretrained_feat_to_wave_trainer(monkeypatch: MonkeyPa
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -680,15 +681,15 @@ def test_feat_to_wave_trainer(
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=pad_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=pad_collate_fn,
@@ -816,19 +817,19 @@ def test_gan_trainer(
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(
+        train_dataset = instantiate(
             config.train.dataset.train,
         )
-        validation_dataset = hydra.utils.instantiate(
+        validation_dataset = instantiate(
             config.train.dataset.validation,
         )
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=gan_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=gan_collate_fn,
@@ -1019,19 +1020,19 @@ def test_gan_trainer_ddp(monkeypatch: MonkeyPatch, train_name: str, dataloader_t
         )
         torch.manual_seed(config.system.seed)
 
-        train_dataset = hydra.utils.instantiate(
+        train_dataset = instantiate(
             config.train.dataset.train,
         )
-        validation_dataset = hydra.utils.instantiate(
+        validation_dataset = instantiate(
             config.train.dataset.validation,
         )
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=gan_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=gan_collate_fn,
@@ -1116,10 +1117,10 @@ def test_gan_trainer_ddp(monkeypatch: MonkeyPatch, train_name: str, dataloader_t
 
         torch.manual_seed(config.system.seed)
 
-        train_dataset = hydra.utils.instantiate(
+        train_dataset = instantiate(
             config.train.dataset.train,
         )
-        validation_dataset = hydra.utils.instantiate(
+        validation_dataset = instantiate(
             config.train.dataset.validation,
         )
 
@@ -1203,15 +1204,15 @@ def test_cascade_text_to_wave(monkeypatch: MonkeyPatch) -> None:
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -1273,15 +1274,15 @@ def test_cascade_text_to_wave(monkeypatch: MonkeyPatch) -> None:
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -1339,9 +1340,9 @@ def test_cascade_text_to_wave(monkeypatch: MonkeyPatch) -> None:
                 return_hydra_config=True,
             )
 
-        test_dataset = hydra.utils.instantiate(config.test.dataset.test)
+        test_dataset = instantiate(config.test.dataset.test)
 
-        test_loader = hydra.utils.instantiate(
+        test_loader = instantiate(
             config.test.dataloader.test,
             test_dataset,
             collate_fn=default_collate_fn,
@@ -1407,15 +1408,15 @@ def test_trainer_for_dataloader(monkeypatch: MonkeyPatch, dataloader: str) -> No
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -1620,15 +1621,15 @@ def test_trainer_for_dump_format_conversion(
             config.train.dataset.validation, dump_format=preprocess_dump_format
         )
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,
@@ -1700,15 +1701,15 @@ def test_trainer_for_list_optimizer(monkeypatch: MonkeyPatch) -> None:
 
         setup_system(config)
 
-        train_dataset = hydra.utils.instantiate(config.train.dataset.train)
-        validation_dataset = hydra.utils.instantiate(config.train.dataset.validation)
+        train_dataset = instantiate(config.train.dataset.train)
+        validation_dataset = instantiate(config.train.dataset.validation)
 
-        train_loader = hydra.utils.instantiate(
+        train_loader = instantiate(
             config.train.dataloader.train,
             train_dataset,
             collate_fn=default_collate_fn,
         )
-        validation_loader = hydra.utils.instantiate(
+        validation_loader = instantiate(
             config.train.dataloader.validation,
             validation_dataset,
             collate_fn=default_collate_fn,


### PR DESCRIPTION
## Summary
This PR addresses #69.

Use `audyn.utils.instantiate` instead of `hydra.utils.instantiate`.