### PR TITLE
Use FlashAttention if possible

### DIFF
--- a/audyn/functional/activation.py
+++ b/audyn/functional/activation.py
@@ -1,0 +1,119 @@
+import math
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from packaging import version
+
+IS_TORCH_LT_2_0 = version.parse(torch.__version__) < version.parse("2.0")
+IS_TORCH_LT_2_1 = version.parse(torch.__version__) < version.parse("2.1")
+
+
+def scaled_dot_product_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    key_padding_mask: Optional[torch.BoolTensor] = None,
+    attn_mask: Optional[torch.BoolTensor] = None,
+    dropout_p: float = 0.0,
+    need_weights: bool = False,
+    **kwargs,
+) -> torch.Tensor:
+    """Wrapper function of torch.nn.functional.scaled_dot_product_attention.
+
+    torch.nn.functional.scaled_dot_product_attention supports memory-efficient attention
+    mechanisms, but it is not implemented in the previous torch (< 2.0). To absorb this difference,
+    this function is designed.
+
+    Args:
+        query (torch.Tensor): Query of shape (batch_size, num_heads, query_length, head_dim).
+        key (torch.Tensor): Key of shape (batch_size, num_heads, key_length, head_dim).
+        value (torch.Tensor): Value of shape (batch_size, num_heads, key_length, head_dim).
+        key_padding_mask (torch.BoolTensor, optional): Padding mask of shape
+            (batch_size, key_length).
+        attn_mask (torch.BoolTensor, optional): Attention padding mask of
+            shape (query_length, key_length) or
+            (batch_size * num_heads, query_length, key_length).
+        dropout_p (float): Dropout rate. To deactivate, you have to explicitly set ``dropout_p=0``.
+        need_weights (bool): If ``True``, attention weight is returned.
+        is_causal (bool, optional): This parameter is supported by ``torch>=2.0``.
+        scale (float, optional): This parameter is supported by ``torch>=2.1``.
+
+    Returns:
+        torch.Tensor: Output of shape (batch_size, num_heads, query_length, head_dim).
+
+    """
+    if IS_TORCH_LT_2_0 or need_weights:
+        use_sdpa = False
+    else:
+        use_sdpa = True
+
+    valid_keys = set()
+
+    if not IS_TORCH_LT_2_0:
+        valid_keys.add("is_causal")
+
+    if not IS_TORCH_LT_2_1:
+        valid_keys.add("scale")
+
+    invalid_keys = set(kwargs.keys()) - valid_keys
+
+    assert invalid_keys == set(), f"Invalid keys {invalid_keys} are given."
+
+    batch_size, num_heads, key_length, head_dim = key.size()
+
+    key_padding_mask = F._canonical_mask(
+        mask=key_padding_mask,
+        mask_name="key_padding_mask",
+        other_type=F._none_or_dtype(attn_mask),
+        other_name="attn_mask",
+        target_type=query.dtype,
+    )
+
+    attn_mask = F._canonical_mask(
+        mask=attn_mask,
+        mask_name="attn_mask",
+        other_type=None,
+        other_name="",
+        target_type=query.dtype,
+        check_other=False,
+    )
+
+    if key_padding_mask is not None:
+        key_padding_mask = key_padding_mask.view(batch_size, 1, 1, key_length)
+
+        if attn_mask is None:
+            attn_mask = key_padding_mask
+        else:
+            if attn_mask.dim() == 3:
+                attn_mask.view(batch_size, num_heads, -1, key_length)
+            else:
+                assert attn_mask.dim() == 2
+
+            attn_mask = attn_mask + key_padding_mask
+
+    if use_sdpa:
+        output = F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            **kwargs,
+        )
+        attn_weights = None
+    else:
+        key = key.transpose(-2, -1)
+        qk = torch.matmul(query, key) / math.sqrt(head_dim)
+
+        if attn_mask is not None:
+            qk = qk + attn_mask
+
+        attn_weights = F.softmax(qk, dim=-1)
+
+        if dropout_p > 0:
+            attn_weights = F.dropout(attn_weights, p=dropout_p)
+
+        output = torch.matmul(attn_weights, value)
+
+    return output, attn_weights

--- a/audyn/modules/activation.py
+++ b/audyn/modules/activation.py
@@ -38,7 +38,6 @@ class _MultiheadAttention(nn.MultiheadAttention):
             "dtype": dtype,
         }
 
-        # Key and value are identical to query.
         super().__init__(
             embed_dim,
             num_heads,
@@ -51,12 +50,6 @@ class _MultiheadAttention(nn.MultiheadAttention):
             batch_first=batch_first,
             **factory_kwargs,
         )
-
-        if not self._qkv_same_embed_dim:
-            raise ValueError(
-                "Embedding dimensions of key and value should be equal to "
-                "that of query in self-attention."
-            )
 
     def forward(
         self,

--- a/audyn/modules/activation.py
+++ b/audyn/modules/activation.py
@@ -15,6 +15,8 @@ __all__ = [
     "ExtrapolatablePositionalMultiheadAttention",
 ]
 
+IS_TORCH_LT_2_0 = version.parse(torch.__version__) < version.parse("2.0")
+
 
 class _MultiheadAttention(nn.MultiheadAttention):
     """Wrapper class of nn.MultiheadAttention."""
@@ -79,7 +81,7 @@ class _MultiheadAttention(nn.MultiheadAttention):
         """Validate keyword arguments for backward compatibility."""
         valid_keys = set()
 
-        if version.parse(torch.__version__) < version.parse("2.0"):
+        if IS_TORCH_LT_2_0:
             valid_keys.add("is_causal")
 
         invalid_keys = set(kwargs.keys()) - valid_keys

--- a/audyn/modules/activation.py
+++ b/audyn/modules/activation.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from packaging import version
 
+from ..functional.activation import scaled_dot_product_attention
 from .positional_encoding import ExtrapolatablePositionalEmbedding, RotaryPositionalEmbedding
 
 __all__ = [
@@ -305,32 +306,20 @@ class TrainableAbsolutePositionalMultiheadAttention(_MultiheadAttention):
         v = self._apply_pos_emb(v, v_pos_emb)
 
         q = q.permute(1, 2, 0, 3)
-        k = k.permute(1, 2, 3, 0)
+        k = k.permute(1, 2, 0, 3)
         v = v.permute(1, 2, 0, 3)
-        qk = torch.matmul(q, k) / math.sqrt(head_dim)
 
-        if key_padding_mask is not None:
-            key_padding_mask = key_padding_mask.view(batch_size, 1, 1, key_length)
+        dropout_p = dropout if self.training else 0
 
-            if attn_mask is None:
-                attn_mask = key_padding_mask
-            else:
-                if attn_mask.dim() == 3:
-                    attn_mask.view(batch_size, num_heads, query_length, key_length)
-                else:
-                    assert attn_mask.dim() == 2
-
-                attn_mask = attn_mask + key_padding_mask
-
-        if attn_mask is not None:
-            qk = qk + attn_mask
-
-        attn_weights = F.softmax(qk, dim=-1)
-
-        if dropout > 0:
-            attn_weights = F.dropout(attn_weights, p=dropout, training=self.training)
-
-        qkv = torch.matmul(attn_weights, v)
+        qkv, attn_weights = scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            key_padding_mask=key_padding_mask,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            need_weights=need_weights,
+        )
 
         if batch_first:
             qkv = qkv.permute(0, 2, 1, 3).contiguous()
@@ -833,23 +822,6 @@ class RotaryPositionalMultiheadAttention(_MultiheadAttention):
         query_length, batch_size, _ = query.size()
         key_length, _, _ = key.size()
 
-        key_padding_mask = F._canonical_mask(
-            mask=key_padding_mask,
-            mask_name="key_padding_mask",
-            other_type=F._none_or_dtype(attn_mask),
-            other_name="attn_mask",
-            target_type=query.dtype,
-        )
-
-        attn_mask = F._canonical_mask(
-            mask=attn_mask,
-            mask_name="attn_mask",
-            other_type=None,
-            other_name="",
-            target_type=query.dtype,
-            check_other=False,
-        )
-
         if self._qkv_same_embed_dim:
             q_proj_weight, k_proj_weight, v_proj_weight = torch.split(
                 in_proj_weight, [embed_dim] * 3, dim=-2
@@ -878,33 +850,20 @@ class RotaryPositionalMultiheadAttention(_MultiheadAttention):
         v = v.view(key_length, batch_size, num_heads, head_dim)
 
         q = q.permute(1, 2, 0, 3)
-        k = k.permute(1, 2, 3, 0)
+        k = k.permute(1, 2, 0, 3)
         v = v.permute(1, 2, 0, 3)
 
-        qk = torch.matmul(q, k) / math.sqrt(head_dim)
+        dropout_p = dropout if self.training else 0
 
-        if key_padding_mask is not None:
-            key_padding_mask = key_padding_mask.view(batch_size, 1, 1, key_length)
-
-            if attn_mask is None:
-                attn_mask = key_padding_mask
-            else:
-                if attn_mask.dim() == 3:
-                    attn_mask.view(batch_size, num_heads, query_length, key_length)
-                else:
-                    assert attn_mask.dim() == 2
-
-                attn_mask = attn_mask + key_padding_mask
-
-        if attn_mask is not None:
-            qk = qk + attn_mask
-
-        attn_weights = F.softmax(qk, dim=-1)
-
-        if dropout > 0:
-            attn_weights = F.dropout(attn_weights, p=dropout, training=self.training)
-
-        qkv = torch.matmul(attn_weights, v)
+        qkv, attn_weights = scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            key_padding_mask=key_padding_mask,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            need_weights=need_weights,
+        )
 
         if batch_first:
             qkv = qkv.permute(0, 2, 1, 3).contiguous()
@@ -1064,23 +1023,6 @@ class ExtrapolatablePositionalMultiheadAttention(_MultiheadAttention):
         query_length, batch_size, _ = query.size()
         key_length, _, _ = key.size()
 
-        key_padding_mask = F._canonical_mask(
-            mask=key_padding_mask,
-            mask_name="key_padding_mask",
-            other_type=F._none_or_dtype(attn_mask),
-            other_name="attn_mask",
-            target_type=query.dtype,
-        )
-
-        attn_mask = F._canonical_mask(
-            mask=attn_mask,
-            mask_name="attn_mask",
-            other_type=None,
-            other_name="",
-            target_type=query.dtype,
-            check_other=False,
-        )
-
         if self._qkv_same_embed_dim:
             q_proj_weight, k_proj_weight, v_proj_weight = torch.split(
                 in_proj_weight, [embed_dim] * 3, dim=-2
@@ -1109,33 +1051,20 @@ class ExtrapolatablePositionalMultiheadAttention(_MultiheadAttention):
         v = v.view(key_length, batch_size, num_heads, head_dim)
 
         q = q.permute(1, 2, 0, 3)
-        k = k.permute(1, 2, 3, 0)
+        k = k.permute(1, 2, 0, 3)
         v = v.permute(1, 2, 0, 3)
 
-        qk = torch.matmul(q, k) / math.sqrt(head_dim)
+        dropout_p = dropout if self.training else 0
 
-        if key_padding_mask is not None:
-            key_padding_mask = key_padding_mask.view(batch_size, 1, 1, key_length)
-
-            if attn_mask is None:
-                attn_mask = key_padding_mask
-            else:
-                if attn_mask.dim() == 3:
-                    attn_mask.view(batch_size, num_heads, query_length, key_length)
-                else:
-                    assert attn_mask.dim() == 2
-
-                attn_mask = attn_mask + key_padding_mask
-
-        if attn_mask is not None:
-            qk = qk + attn_mask
-
-        attn_weights = F.softmax(qk, dim=-1)
-
-        if dropout > 0:
-            attn_weights = F.dropout(attn_weights, p=dropout, training=self.training)
-
-        qkv = torch.matmul(attn_weights, v)
+        qkv, attn_weights = scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            key_padding_mask=key_padding_mask,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            need_weights=need_weights,
+        )
 
         if batch_first:
             qkv = qkv.permute(0, 2, 1, 3).contiguous()

--- a/audyn/modules/activation.py
+++ b/audyn/modules/activation.py
@@ -330,7 +330,7 @@ class TrainableAbsolutePositionalMultiheadAttention(_MultiheadAttention):
 
         output = self.out_proj(qkv)
 
-        if average_attn_weights:
+        if average_attn_weights and need_weights:
             attn_weights = attn_weights.mean(dim=1)
 
         if not need_weights:
@@ -639,7 +639,7 @@ class RelativePositionalMultiheadAttention(_MultiheadAttention):
 
         output = self.out_proj(qkv)
 
-        if average_attn_weights:
+        if average_attn_weights and need_weights:
             attn_weights = attn_weights.mean(dim=1)
 
         if not need_weights:
@@ -874,7 +874,7 @@ class RotaryPositionalMultiheadAttention(_MultiheadAttention):
 
         output = self.out_proj(qkv)
 
-        if average_attn_weights:
+        if average_attn_weights and need_weights:
             attn_weights = attn_weights.mean(dim=1)
 
         if not need_weights:
@@ -1075,7 +1075,7 @@ class ExtrapolatablePositionalMultiheadAttention(_MultiheadAttention):
 
         output = self.out_proj(qkv)
 
-        if average_attn_weights:
+        if average_attn_weights and need_weights:
             attn_weights = attn_weights.mean(dim=1)
 
         if not need_weights:

--- a/audyn/modules/activation.py
+++ b/audyn/modules/activation.py
@@ -81,7 +81,7 @@ class _MultiheadAttention(nn.MultiheadAttention):
         """Validate keyword arguments for backward compatibility."""
         valid_keys = set()
 
-        if IS_TORCH_LT_2_0:
+        if not IS_TORCH_LT_2_0:
             valid_keys.add("is_causal")
 
         invalid_keys = set(kwargs.keys()) - valid_keys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,10 @@ import pytest
 
 def pytest_configure():
     max_number = 2**16
+    min_number = 1024
 
     seed = str(uuid.uuid4())
     seed = seed.replace("-", "")
     seed = int(seed, 16)
 
-    pytest.random_port = seed % max_number
+    pytest.random_port = seed % (max_number - min_number) + min_number

--- a/tests/package/functional/test_functional_activation.py
+++ b/tests/package/functional/test_functional_activation.py
@@ -1,0 +1,145 @@
+import math
+from typing import Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+from dummy import allclose
+from packaging import version
+
+from audyn.functional.activation import scaled_dot_product_attention
+
+
+@pytest.mark.parametrize("use_key_padding_mask", [True, False])
+@pytest.mark.parametrize("use_attn_mask", [True, False])
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse("2.0"), reason="torch >= 2.0 is required."
+)
+def test_scaled_dot_product_attention(use_key_padding_mask: bool, use_attn_mask: bool) -> None:
+    torch.manual_seed(0)
+
+    batch_first = True
+    num_heads, head_dim = 8, 6
+    max_query_length, max_key_length = 12, 10
+    batch_size, query_length, key_length = 4, 10, 12
+
+    (query, key, value), (query_length, key_length) = create_qkv(
+        batch_size,
+        max_query_length,
+        max_key_length,
+        num_heads,
+        head_dim,
+        batch_first=batch_first,
+    )
+    max_query_length = torch.max(query_length).item()
+    max_key_length = torch.max(key_length).item()
+
+    if batch_first:
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+    else:
+        query = query.transpose(0, 2)
+        key = key.transpose(0, 2)
+        value = value.transpose(0, 2)
+
+    key_padding_mask, attn_mask = create_padding_masks(query_length, key_length)
+
+    if not use_key_padding_mask:
+        key_padding_mask = None
+
+    if not use_attn_mask:
+        attn_mask = None
+
+    output_sdpa, _ = scaled_dot_product_attention(
+        query, key, value, key_padding_mask=key_padding_mask, attn_mask=attn_mask
+    )
+
+    key_padding_mask = F._canonical_mask(
+        mask=key_padding_mask,
+        mask_name="key_padding_mask",
+        other_type=F._none_or_dtype(attn_mask),
+        other_name="attn_mask",
+        target_type=query.dtype,
+    )
+
+    attn_mask = F._canonical_mask(
+        mask=attn_mask,
+        mask_name="attn_mask",
+        other_type=None,
+        other_name="",
+        target_type=query.dtype,
+        check_other=False,
+    )
+
+    if key_padding_mask is not None:
+        key_padding_mask = key_padding_mask.view(batch_size, 1, 1, max_key_length)
+
+        if attn_mask is None:
+            attn_mask = key_padding_mask
+        else:
+            if attn_mask.dim() == 3:
+                attn_mask.view(batch_size, num_heads, -1, max_key_length)
+            else:
+                assert attn_mask.dim() == 2
+
+            attn_mask = attn_mask + key_padding_mask
+
+    key = key.transpose(-2, -1)
+    qk = torch.matmul(query, key) / math.sqrt(head_dim)
+
+    if attn_mask is not None:
+        qk = qk + attn_mask
+
+    attn_weights = F.softmax(qk, dim=-1)
+
+    output_naive = torch.matmul(attn_weights, value)
+
+    allclose(output_sdpa, output_naive, atol=1e-6)
+
+
+def create_qkv(
+    batch_size: int,
+    max_query_length: int,
+    max_key_length: int,
+    num_heads: int,
+    head_dim: int,
+    batch_first: bool = False,
+) -> Tuple[
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor], Tuple[torch.LongTensor, torch.LongTensor]
+]:
+    query_length = torch.randint(max_query_length // 2, max_query_length, (batch_size,))
+    max_query_length = torch.max(query_length).item()
+    key_length = torch.randint(max_key_length // 2, max_key_length, (batch_size,))
+    max_key_length = torch.max(key_length).item()
+
+    query = torch.randn(max_query_length, batch_size, num_heads, head_dim)
+    key = torch.randn(max_key_length, batch_size, num_heads, head_dim)
+    value = torch.randn(max_key_length, batch_size, num_heads, head_dim)
+
+    if batch_first:
+        query = query.transpose(1, 0)
+        key = key.transpose(1, 0)
+        value = value.transpose(1, 0)
+
+    return (query, key, value), (query_length, key_length)
+
+
+def create_padding_masks(
+    query_length: torch.LongTensor,
+    key_length: torch.LongTensor,
+) -> Tuple[torch.BoolTensor, torch.BoolTensor]:
+    max_query_length = torch.max(query_length).item()
+    max_key_length = torch.max(key_length).item()
+
+    query_pos_indices = torch.arange(max_query_length)
+    key_pos_indices = torch.arange(max_key_length)
+    key_padding_mask = key_pos_indices >= key_length.unsqueeze(dim=-1)
+
+    if max_query_length > max_key_length:
+        attn_mask = key_pos_indices > query_pos_indices.unsqueeze(dim=-1)
+    else:
+        attn_mask = key_pos_indices < query_pos_indices.unsqueeze(dim=-1)
+        attn_mask = torch.flip(attn_mask, dims=(-2, -1))
+
+    return key_padding_mask, attn_mask

--- a/tests/package/models/test_lextransformer.py
+++ b/tests/package/models/test_lextransformer.py
@@ -17,7 +17,7 @@ def test_lextransformer_encoder_layer(batch_first: bool) -> None:
     d_model, nhead, dim_feedforward = 8, 2, 3
     batch_size, src_length = 4, 16
     xpos_base = 100
-    shift_size = 3
+    shift_size = src_length
 
     model = LEXTransformerEncoderLayer(
         d_model,
@@ -64,7 +64,7 @@ def test_lextransformer_decoder_layer(batch_first: bool) -> None:
     d_model, nhead, dim_feedforward = 8, 2, 3
     batch_size, tgt_length, memory_length = 4, 16, 20
     xpos_base = 100
-    shift_size = 3
+    shift_size = tgt_length
 
     model = LEXTransformerDecoderLayer(
         d_model,
@@ -127,7 +127,7 @@ def test_lextransformer_encoder(batch_first: bool) -> None:
     num_layers = 5
     batch_size, src_length = 4, 16
     xpos_base = 100
-    shift_size = 3
+    shift_size = src_length
 
     model = LEXTransformerEncoder(
         d_model,
@@ -176,7 +176,7 @@ def test_lextransformer_decoder(batch_first: bool) -> None:
     num_layers = 5
     batch_size, tgt_length, memory_length = 4, 16, 20
     xpos_base = 100
-    shift_size = 3
+    shift_size = tgt_length
 
     model = LEXTransformerDecoder(
         d_model,

--- a/tests/package/models/test_roformer.py
+++ b/tests/package/models/test_roformer.py
@@ -122,7 +122,7 @@ def test_roformer_encoder(batch_first: bool) -> None:
     d_model, nhead, dim_feedforward = 8, 2, 3
     num_layers = 5
     batch_size, src_length = 4, 16
-    shift_size = 3
+    shift_size = src_length
 
     model = RoformerEncoder(
         d_model,
@@ -169,7 +169,7 @@ def test_roformer_decoder(batch_first: bool) -> None:
     d_model, nhead, dim_feedforward = 8, 2, 3
     num_layers = 5
     batch_size, tgt_length, memory_length = 4, 16, 20
-    shift_size = 3
+    shift_size = tgt_length
 
     model = RoformerDecoder(
         d_model,


### PR DESCRIPTION
## Summary
With `torch>=2.0`, we can use flash attention if possible. However, it is not employed in our attention modules.
To activate this useful feature, we added a wrapper function of `F.scaled_dot_product_attention`.

close #68