### PR TITLE
Support `torch.hub`

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -81,6 +81,7 @@ jobs:
           python tests/scripts/verify_torch_version.py --torch-version ${TORCH_VERSION}
       - name: Pytest
         env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
           pytest -vvv --cov=audyn/ --cov-report=xml tests/package/

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -80,6 +80,7 @@ jobs:
         run: |
           python tests/scripts/verify_torch_version.py --torch-version ${TORCH_VERSION}
       - name: Pytest for torch.hub
+        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest' && matrix.torch-version == '2.1.0'
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -79,9 +79,13 @@ jobs:
           TORCH_VERSION: ${{ matrix.torch-version }}
         run: |
           python tests/scripts/verify_torch_version.py --torch-version ${TORCH_VERSION}
-      - name: Pytest
+      - name: Pytest for torch.hub
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          pytest -vvv tests/torchhub/
+      - name: Pytest for package
+        env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
           pytest -vvv --cov=audyn/ --cov-report=xml tests/package/

--- a/PRETRAINED_MODELS.md
+++ b/PRETRAINED_MODELS.md
@@ -1,0 +1,51 @@
+# Pretrained models via torch.hub
+
+## Self-supervised audio spectrogram transformer (SSAST)
+- Provided weights are extracted from the original implementation.
+- SSAST for pretraining
+
+```python
+>>> import torch
+>>> repo = "tky823/Audyn"
+>>> model = "multitask_ssast_base_400"
+>>> # patch-based SSAST
+>>> token_unit = "patch"
+>>> patch_based_ssast = torch.hub.load(
+...     repo,
+...     model,
+...     skip_validation=False,
+...     token_unit=token_unit,
+... )
+>>> # frame-based SSAST
+>>> token_unit = "frame"
+>>> frame_based_ssast = torch.hub.load(
+...     repo,
+...     model,
+...     skip_validation=False,
+...     token_unit=token_unit,
+... )
+```
+
+- SSAST for finetuning
+
+```python
+>>> import torch
+>>> repo = "tky823/Audyn"
+>>> model = "ssast_base_400"
+>>> # patch-based SSAST
+>>> token_unit = "patch"
+>>> patch_based_ssast = torch.hub.load(
+...     repo,
+...     model,
+...     skip_validation=False,
+...     token_unit=token_unit,
+... )
+>>> # frame-based SSAST
+>>> token_unit = "frame"
+>>> frame_based_ssast = torch.hub.load(
+...     repo,
+...     model,
+...     skip_validation=False,
+...     token_unit=token_unit,
+... )
+```

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,75 @@
+from typing import Optional
+
+import torch.nn as nn
+from torch.nn.common_types import _size_2_t
+
+from audyn.models.ssast import (
+    MultiTaskSelfSupervisedAudioSpectrogramTransformerMaskedPatchModel as _MultiTaskSSASTMPM,
+)
+from audyn.models.ssast import SelfSupervisedAudioSpectrogramTransformer as _SSAST
+
+
+def multitask_ssast_mpm(
+    pretrained_model_name: str,
+    stride: Optional[_size_2_t] = None,
+    n_bins: Optional[int] = None,
+    n_frames: Optional[int] = None,
+    reconstructor: Optional[nn.Module] = None,
+    classifier: Optional[nn.Module] = None,
+) -> _MultiTaskSSASTMPM:
+    """Build SelfSupervisedAudioSpectrogramTransformer.
+
+    Args:
+        pretrained_model_name (str): Pretrained model name.
+
+    .. note::
+
+        Supported pretrained model names are
+            - multitask-ssast-patch-base-400
+            - multitask-ssast-frame-base-400
+
+    """
+    model = _MultiTaskSSASTMPM.build_from_pretrained(
+        pretrained_model_name,
+        stride=stride,
+        n_bins=n_bins,
+        n_frames=n_frames,
+        reconstructor=reconstructor,
+        classifier=classifier,
+    )
+
+    return model
+
+
+def ssast(
+    pretrained_model_name: str,
+    stride: Optional[_size_2_t] = None,
+    n_bins: Optional[int] = None,
+    n_frames: Optional[int] = None,
+    aggregator: Optional[nn.Module] = None,
+    head: Optional[nn.Module] = None,
+) -> _SSAST:
+    """Build SelfSupervisedAudioSpectrogramTransformer.
+
+    Args:
+        pretrained_model_name (str): Pretrained model name.
+        aggregator (nn.Module, optional): Aggregator module.
+        head (nn.Module, optional): Head module.
+
+    .. note::
+
+        Supported pretrained model names are
+            - multitask-ssast-patch-base-400
+            - multitask-ssast-frame-base-400
+
+    """
+    model = _SSAST.build_from_pretrained(
+        pretrained_model_name,
+        stride=stride,
+        n_bins=n_bins,
+        n_frames=n_frames,
+        aggregator=aggregator,
+        head=head,
+    )
+
+    return model

--- a/hubconf.py
+++ b/hubconf.py
@@ -9,8 +9,8 @@ from audyn.models.ssast import (
 from audyn.models.ssast import SelfSupervisedAudioSpectrogramTransformer as _SSAST
 
 
-def multitask_ssast_mpm(
-    pretrained_model_name: str,
+def multitask_ssast_base_400(
+    token_unit: str = "patch",
     stride: Optional[_size_2_t] = None,
     n_bins: Optional[int] = None,
     n_frames: Optional[int] = None,
@@ -20,15 +20,16 @@ def multitask_ssast_mpm(
     """Build SelfSupervisedAudioSpectrogramTransformer.
 
     Args:
-        pretrained_model_name (str): Pretrained model name.
-
-    .. note::
-
-        Supported pretrained model names are
-            - multitask-ssast-patch-base-400
-            - multitask-ssast-frame-base-400
+        token_unit (str): Token unit. ``patch`` and ``frame`` are supported.
 
     """
+    if token_unit == "patch":
+        pretrained_model_name = "multitask-ssast-patch-base-400"
+    elif token_unit == "frame":
+        pretrained_model_name = "multitask-ssast-frame-base-400"
+    else:
+        raise ValueError(f"{token_unit} is not supported as token_unit.")
+
     model = _MultiTaskSSASTMPM.build_from_pretrained(
         pretrained_model_name,
         stride=stride,
@@ -41,8 +42,8 @@ def multitask_ssast_mpm(
     return model
 
 
-def ssast(
-    pretrained_model_name: str,
+def ssast_base_400(
+    token_unit: str = "patch",
     stride: Optional[_size_2_t] = None,
     n_bins: Optional[int] = None,
     n_frames: Optional[int] = None,
@@ -52,17 +53,18 @@ def ssast(
     """Build SelfSupervisedAudioSpectrogramTransformer.
 
     Args:
-        pretrained_model_name (str): Pretrained model name.
+        token_unit (str): Token unit. ``patch`` and ``frame`` are supported.
         aggregator (nn.Module, optional): Aggregator module.
         head (nn.Module, optional): Head module.
 
-    .. note::
-
-        Supported pretrained model names are
-            - multitask-ssast-patch-base-400
-            - multitask-ssast-frame-base-400
-
     """
+    if token_unit == "patch":
+        pretrained_model_name = "multitask-ssast-patch-base-400"
+    elif token_unit == "frame":
+        pretrained_model_name = "multitask-ssast-frame-base-400"
+    else:
+        raise ValueError(f"{token_unit} is not supported as token_unit.")
+
     model = _SSAST.build_from_pretrained(
         pretrained_model_name,
         stride=stride,

--- a/tests/torchhub/test_ssast.py
+++ b/tests/torchhub/test_ssast.py
@@ -6,7 +6,7 @@ import torch
 def test_multitask_ssast_mpm(token_unit: str) -> None:
     torch.manual_seed(0)
 
-    repo = "tky823/Audyn:feature/hubconf"
+    repo = "tky823/Audyn"
     model = "multitask_ssast_base_400"
     batch_size = 4
     n_bins, n_frames = 128, 1024
@@ -44,7 +44,7 @@ def test_multitask_ssast_mpm(token_unit: str) -> None:
 def test_ssast(token_unit: str) -> None:
     torch.manual_seed(0)
 
-    repo = "tky823/Audyn:feature/hubconf"
+    repo = "tky823/Audyn"
     model = "ssast_base_400"
     batch_size = 4
     n_bins, n_frames = 128, 100

--- a/tests/torchhub/test_ssast.py
+++ b/tests/torchhub/test_ssast.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("token_unit", ["patch", "frame"])
+def test_multitask_ssast_mpm(token_unit: str) -> None:
+    torch.manual_seed(0)
+
+    repo = "tky823/Audyn:feature/hubconf"
+    model = "multitask_ssast_base_400"
+    batch_size = 4
+    n_bins, n_frames = 128, 1024
+
+    model = torch.hub.load(
+        repo,
+        model,
+        skip_validation=False,
+        token_unit=token_unit,
+    )
+
+    input = torch.randn((batch_size, n_bins, n_frames))
+
+    with torch.no_grad():
+        output = model(input)
+
+    reconstruction_output, classification_output = output
+    reconstruction_output, reconstruction_target, reconstruction_length = reconstruction_output
+    classification_output, classification_target, classification_length = classification_output
+
+    assert reconstruction_output.size(0) == batch_size
+    assert reconstruction_output.size(2) == 256
+    assert reconstruction_target.size(0) == batch_size
+    assert reconstruction_target.size(2) == 256
+    assert reconstruction_length.size() == (batch_size,)
+
+    assert classification_output.size(0) == batch_size
+    assert classification_output.size(2) == 256
+    assert classification_target.size(0) == batch_size
+    assert classification_target.size(2) == 256
+    assert classification_length.size() == (batch_size,)
+
+
+@pytest.mark.parametrize("token_unit", ["patch", "frame"])
+def test_ssast(token_unit: str) -> None:
+    torch.manual_seed(0)
+
+    repo = "tky823/Audyn:feature/hubconf"
+    model = "ssast_base_400"
+    batch_size = 4
+    n_bins, n_frames = 128, 100
+
+    if token_unit == "patch":
+        stride = (10, 10)
+    elif token_unit == "frame":
+        stride = (n_bins, 1)
+    else:
+        raise ValueError(f"{token_unit} is not supported as token_unit.")
+
+    model = torch.hub.load(
+        repo,
+        model,
+        skip_validation=False,
+        token_unit=token_unit,
+        stride=stride,
+        n_frames=n_frames,
+    )
+
+    input = torch.randn((batch_size, n_bins, n_frames))
+
+    with torch.no_grad():
+        output = model(input)
+
+    assert output.size(0) == batch_size
+    assert output.size(2) == 768

--- a/tests/torchhub/test_ssast.py
+++ b/tests/torchhub/test_ssast.py
@@ -70,5 +70,9 @@ def test_ssast(token_unit: str) -> None:
     with torch.no_grad():
         output = model(input)
 
-    assert output.size(0) == batch_size
-    assert output.size(2) == 768
+    if token_unit == "patch":
+        assert output.size() == (batch_size, 768, 12, 9)
+    elif token_unit == "frame":
+        assert output.size() == (batch_size, 768, 1, 99)
+    else:
+        raise ValueError(f"{token_unit} is not supported as token_unit.")


### PR DESCRIPTION
## Summary
This PR adds `hubconf.py`, which will be used via `torch.hub`.
As a first step, pretrained `SSAST` is provided.