### PR TITLE
Rename Roformer to RoFormer

### DIFF
--- a/audyn/models/roformer.py
+++ b/audyn/models/roformer.py
@@ -1,4 +1,4 @@
-"""Implementation of Roformer.
+"""Implementation of RoFormer.
 Ported from https://github.com/pytorch/pytorch/blob/e8836759d0898c29262b5370e16970d697cbaf3a/torch/nn/modules/transformer.py.  # noqa: E501
 """
 
@@ -12,8 +12,8 @@ from packaging import version
 from ..modules.activation import RotaryPositionalMultiheadAttention
 
 __all__ = [
-    "RoformerEncoder",
-    "RoformerDecoder",
+    "RoFormerEncoder",
+    "RoFormerDecoder",
     "RoFormerEncoderLayer",
     "RoFormerDecoderLayer",
 ]
@@ -21,7 +21,7 @@ __all__ = [
 IS_TORCH_LT_2_1 = version.parse(torch.__version__) < version.parse("2.1")
 
 
-class RoformerEncoder(nn.TransformerEncoder):
+class RoFormerEncoder(nn.TransformerEncoder):
     """Encoder of RoFormer."""
 
     def __init__(
@@ -68,7 +68,7 @@ class RoformerEncoder(nn.TransformerEncoder):
         )
 
 
-class RoformerDecoder(nn.TransformerDecoder):
+class RoFormerDecoder(nn.TransformerDecoder):
     """Decoder of RoFormer."""
 
     def __init__(

--- a/audyn/modules/positional_encoding.py
+++ b/audyn/modules/positional_encoding.py
@@ -68,7 +68,7 @@ class RotaryPositionalEmbedding(nn.Module):
     """RoPE: Rotary positional embedding proposed in [#su2021roformer]_.
 
     .. [#su2021roformer]
-        J. Su et al., "Roformer: Enhanced transformer with rotary position embedding,"
+        J. Su et al., "RoFormer: Enhanced transformer with rotary position embedding,"
         *Neurocomputing*, vol. 568, 2024.
 
     """

--- a/tests/package/models/test_roformer.py
+++ b/tests/package/models/test_roformer.py
@@ -3,9 +3,9 @@ import torch
 from dummy import allclose
 
 from audyn.models.roformer import (
-    RoformerDecoder,
+    RoFormerDecoder,
     RoFormerDecoderLayer,
-    RoformerEncoder,
+    RoFormerEncoder,
     RoFormerEncoderLayer,
 )
 
@@ -124,7 +124,7 @@ def test_roformer_encoder(batch_first: bool) -> None:
     batch_size, src_length = 4, 16
     shift_size = src_length
 
-    model = RoformerEncoder(
+    model = RoFormerEncoder(
         d_model,
         nhead,
         num_layers=num_layers,
@@ -171,7 +171,7 @@ def test_roformer_decoder(batch_first: bool) -> None:
     batch_size, tgt_length, memory_length = 4, 16, 20
     shift_size = tgt_length
 
-    model = RoformerDecoder(
+    model = RoFormerDecoder(
         d_model,
         nhead,
         num_layers=num_layers,


### PR DESCRIPTION
## Summary
This PR fixes the names of RoFormer-related modules.