### PR TITLE
Rename token to access private repository

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -101,7 +101,7 @@ jobs:
           pytest -vvv tests/torchhub/
       - name: Pytest for package
         env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
           pytest -vvv --cov=audyn/ --cov-report=xml tests/package/
       - name: Upload coverage reports to Codecov

--- a/audyn/utils/github/__init__.py
+++ b/audyn/utils/github/__init__.py
@@ -31,11 +31,11 @@ def download_file_from_github_release(
 
     .. note::
 
-        You may need to set ``GITHUB_ACCESS_TOKEN`` as environmental variable to download
+        You may need to set ``GITHUB_TOKEN`` as environmental variable to download
         private assets.
 
     """
-    token = os.getenv("GITHUB_ACCESS_TOKEN", None)
+    token = os.getenv("GITHUB_TOKEN", None)
 
     if os.path.exists(path):
         if force_download:
@@ -74,7 +74,7 @@ def download_file_from_github_release(
 
 def _obtain_metadata(url: str) -> Tuple[str, int]:
     """Convert browser_download_url to actual url to download."""
-    token = os.getenv("GITHUB_ACCESS_TOKEN", None)
+    token = os.getenv("GITHUB_TOKEN", None)
 
     parsed_url = urlparse(url)
     parsed_url.hostname


### PR DESCRIPTION
## Summary
This PR renames the access token for a private repository.
There are no breaking changes in the usage.

ref: #97