### PR TITLE
MFCC computation for kaldi

### DIFF
--- a/audyn/transforms/kaldi.py
+++ b/audyn/transforms/kaldi.py
@@ -221,10 +221,7 @@ class KaldiMFCC(nn.Module):
             ``frame_shift`` in torchaudio.compliance.kaldi.mfcc.
         f_min (float): Minimum frequency called as low_freq in torchaudio.compliance.kaldi.mfcc.
         f_max (float): Maximum frequency called as high_freq in torchaudio.compliance.kaldi.mfcc.
-        n_mfcc (int): Number of MFCC bins called as num_mel_bins
-            in torchaudio.compliance.kaldi.mfcc.
-        n_mfcc (int): Number of MFCC bins called as num_mel_bins
-            in torchaudio.compliance.kaldi.mfcc.
+        n_mfcc (int): Number of MFCC bins called as num_ceps in torchaudio.compliance.kaldi.mfcc.
         n_mels (int): Number of mel filterbanks called as num_mel_bins in
             torchaudio.compliance.kaldi.fbank.
         power (float, optional): Exponent for the magnitude spectrogram. Only 1 and 2 are

--- a/tests/package/transforms/test_kaldi.py
+++ b/tests/package/transforms/test_kaldi.py
@@ -59,6 +59,27 @@ def test_kaldi_melspectrogram(set_fbank_kwargs: bool) -> None:
 
     assert melspectrogram.size()[:3] == (batch_size, in_channels, n_mels)
 
+    # compatibility
+    waveform = torch.randn((1, timesteps))
+
+    melspectrogram_transform = KaldiMelSpectrogram(
+        sample_rate,
+        win_length=win_length,
+        hop_length=hop_length,
+        n_mels=n_mels,
+    )
+    melspectrogram = melspectrogram_transform(waveform)
+
+    melspectrogram_ack = aCK.fbank(
+        waveform,
+        frame_length=frame_length,
+        frame_shift=frame_shift,
+        num_mel_bins=n_mels,
+        sample_frequency=sample_rate,
+    )
+
+    allclose(melspectrogram, melspectrogram_ack.transpose(1, 0))
+
 
 @pytest.mark.parametrize("set_mfcc_kwargs", [True, False])
 def test_kaldi_mfcc(set_mfcc_kwargs: bool) -> None:

--- a/tests/package/transforms/test_kaldi.py
+++ b/tests/package/transforms/test_kaldi.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from audyn.transforms.kaldi import KaldiMelSpectrogram
+from audyn.transforms.kaldi import KaldiMelSpectrogram, KaldiMFCC
 
 
 @pytest.mark.parametrize("set_fbank_kwargs", [True, False])
@@ -56,3 +56,60 @@ def test_kaldi_melspectrogram(set_fbank_kwargs: bool) -> None:
     melspectrogram = melspectrogram_transform(waveform)
 
     assert melspectrogram.size()[:3] == (batch_size, in_channels, n_mels)
+
+
+@pytest.mark.parametrize("set_mfcc_kwargs", [True, False])
+def test_kaldi_mfcc(set_mfcc_kwargs: bool) -> None:
+    torch.manual_seed(0)
+
+    sample_rate = 16000
+    n_mfcc = 20
+    n_mels = 80
+    frame_length = 25
+    frame_shift = 10
+    win_length = int(frame_length * sample_rate / 1000)
+    hop_length = int(frame_shift * sample_rate / 1000)
+    batch_size, in_channels, timesteps = 4, 1, 16000
+
+    if set_mfcc_kwargs:
+        mfcc_kwargs = {
+            "sample_frequency": sample_rate,
+            "frame_length": frame_length,
+            "frame_shift": frame_shift,
+            "low_freq": 0,
+            "high_freq": sample_rate / 2,
+            "num_mel_bins": n_mels,
+            "use_energy": False,
+        }
+    else:
+        mfcc_kwargs = None
+
+    # 2D input
+    waveform = torch.randn((batch_size, timesteps))
+
+    mfcc_transform = KaldiMFCC(
+        sample_rate,
+        win_length=win_length,
+        hop_length=hop_length,
+        n_mfcc=n_mfcc,
+        n_mels=n_mels,
+        mfcc_kwargs=mfcc_kwargs,
+    )
+    mfcc = mfcc_transform(waveform)
+
+    assert mfcc.size()[:2] == (batch_size, n_mfcc)
+
+    # 3D input
+    waveform = torch.randn((batch_size, in_channels, timesteps))
+
+    mfcc_transform = KaldiMFCC(
+        sample_rate,
+        win_length=win_length,
+        hop_length=hop_length,
+        n_mfcc=n_mfcc,
+        n_mels=n_mels,
+        mfcc_kwargs=mfcc_kwargs,
+    )
+    mfcc = mfcc_transform(waveform)
+
+    assert mfcc.size()[:3] == (batch_size, in_channels, n_mfcc)


### PR DESCRIPTION
## Summary
By this PR, `torchaudio.compliance.kaldi.mfcc` can be used for batch operation.
This will be used for training of HuBERT.

ref: #97