### PR TITLE
Include configs as package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 exclude .gitignore
-exclude *.yaml
 recursive-include audyn *.py
+recursive-include audyn *.yaml
 prune .github
 prune docs
 prune tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ include = [
     "audyn",
 ]
 
+[tool.setuptools.packages.package-data]
+# to include config of drivers
+audyn = [
+    "*yaml",
+]
+
 [tool.black]
 line-length = 99
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ include = [
     "audyn",
 ]
 
-[tool.setuptools.packages.package-data]
+[tool.setuptools.package-data]
 # to include config of drivers
 audyn = [
     "*yaml",


### PR DESCRIPTION
## Summary
`audyn.main` does not work when installing `Audyn` as a package by `pip install git+https://github.com/tky823/Audyn.git` so far. To fix this issue, set `tool.setuptools.packages.package-data`.