### PR TITLE
Support norm by BitLinear

### DIFF
--- a/audyn/modules/normalization.py
+++ b/audyn/modules/normalization.py
@@ -1,3 +1,80 @@
+import numbers
+
+import torch
+import torch.nn as nn
+from torch.nn.modules.normalization import _shape_t
+
 from .glow import ActNorm1d
 
-__all__ = ["ActNorm1d"]
+__all__ = [
+    "ActNorm1d",
+    "RMSNorm",
+]
+
+
+class RMSNorm(nn.Module):
+    """Root mean square layer normalization.
+
+    See https://arxiv.org/abs/1910.07467 for details.
+    """
+
+    # This implementation based on nn.LayerNorm.
+
+    def __init__(
+        self,
+        normalized_shape: _shape_t,
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+        bias: bool = False,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {
+            "device": device,
+            "dtype": dtype,
+        }
+        super().__init__()
+
+        if isinstance(normalized_shape, numbers.Integral):
+            normalized_shape = (normalized_shape,)
+
+        self.normalized_shape = tuple(normalized_shape)
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+
+        if self.elementwise_affine:
+            weight = torch.empty(self.normalized_shape, **factory_kwargs)
+            self.weight = nn.Parameter(weight)
+
+            if bias:
+                bias = torch.empty(self.normalized_shape, **factory_kwargs)
+                self.bias = nn.Parameter(bias)
+            else:
+                self.register_parameter("bias", None)
+        else:
+            self.register_parameter("weight", None)
+            self.register_parameter("bias", None)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self) -> None:
+        if self.elementwise_affine:
+            nn.init.ones_(self.weight)
+
+            if self.bias is not None:
+                nn.init.zeros_(self.bias)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        normalized_shape = self.normalized_shape
+        eps = self.eps
+
+        dim = tuple(range(-1, -len(normalized_shape) - 1, -1))
+        squared_mean = torch.mean(input**2, dim=dim, keepdim=True)
+        x = input / torch.sqrt(squared_mean + eps)
+
+        if self.bias is None:
+            output = self.weight * x
+        else:
+            output = self.weight * x + self.bias
+
+        return output

--- a/audyn/utils/model/bitnet.py
+++ b/audyn/utils/model/bitnet.py
@@ -22,7 +22,7 @@ __all__ = [
 
 def convert_to_bitlinear158(
     module: nn.Module,
-    group_dim: Optional[Union[int, Sequence[int]]] = None,
+    dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
     remove_bias: bool = False,
@@ -45,7 +45,7 @@ def convert_to_bitlinear158(
     elif isinstance(module, nn.Linear):
         module = convert_linear_to_bitlinear158(
             module,
-            group_dim=group_dim,
+            dim=dim,
             bits=bits,
             eps=eps,
             remove_bias=remove_bias,
@@ -53,7 +53,7 @@ def convert_to_bitlinear158(
     elif isinstance(module, nn.MultiheadAttention):
         module = convert_mha_to_bitmha158(
             module,
-            group_dim=group_dim,
+            dim=dim,
             bits=bits,
             eps=eps,
             remove_bias=remove_bias,
@@ -65,7 +65,7 @@ def convert_to_bitlinear158(
             elif isinstance(child_module, nn.Linear):
                 converted = convert_linear_to_bitlinear158(
                     child_module,
-                    group_dim=group_dim,
+                    dim=dim,
                     bits=bits,
                     eps=eps,
                     remove_bias=remove_bias,
@@ -73,7 +73,7 @@ def convert_to_bitlinear158(
             elif isinstance(child_module, nn.MultiheadAttention):
                 converted = convert_mha_to_bitmha158(
                     child_module,
-                    group_dim=group_dim,
+                    dim=dim,
                     bits=bits,
                     eps=eps,
                     remove_bias=remove_bias,
@@ -81,7 +81,7 @@ def convert_to_bitlinear158(
             else:
                 converted = convert_to_bitlinear158(
                     child_module,
-                    group_dim=group_dim,
+                    dim=dim,
                     bits=bits,
                     eps=eps,
                     remove_bias=remove_bias,
@@ -94,7 +94,7 @@ def convert_to_bitlinear158(
 
 def convert_to_bitlinear158_inference(
     module: nn.Module,
-    group_dim: Optional[Union[int, Sequence[int]]] = None,
+    dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
     remove_bias: bool = False,
@@ -117,7 +117,7 @@ def convert_to_bitlinear158_inference(
     """
     module = convert_to_bitlinear158(
         module,
-        group_dim=group_dim,
+        dim=dim,
         bits=bits,
         eps=eps,
         remove_bias=remove_bias,
@@ -142,7 +142,7 @@ def convert_to_bitlinear158_inference(
             else:
                 converted = convert_to_bitlinear158_inference(
                     child_module,
-                    group_dim=group_dim,
+                    dim=dim,
                     bits=bits,
                     eps=eps,
                     remove_bias=remove_bias,
@@ -155,7 +155,7 @@ def convert_to_bitlinear158_inference(
 
 def convert_linear_to_bitlinear158(
     module: nn.Linear,
-    group_dim: Optional[Union[int, Sequence[int]]] = None,
+    dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
     remove_bias: bool = False,
@@ -178,7 +178,7 @@ def convert_linear_to_bitlinear158(
         in_features,
         out_features,
         bias=bias,
-        group_dim=group_dim,
+        dim=dim,
         bits=bits,
         eps=eps,
         **factory_kwargs,
@@ -193,7 +193,7 @@ def convert_linear_to_bitlinear158(
 
 def convert_mha_to_bitmha158(
     module: nn.MultiheadAttention,
-    group_dim: Optional[Union[int, Sequence[int]]] = None,
+    dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
     remove_bias: bool = False,
@@ -246,7 +246,7 @@ def convert_mha_to_bitmha158(
         kdim=kdim,
         vdim=vdim,
         batch_first=batch_first,
-        group_dim=group_dim,
+        dim=dim,
         bits=bits,
         eps=eps,
         **factory_kwargs,

--- a/audyn/utils/model/bitnet.py
+++ b/audyn/utils/model/bitnet.py
@@ -1,6 +1,7 @@
 import copy
-from typing import Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union
 
+import torch
 import torch.nn as nn
 
 from ...modules.bitnet import (
@@ -22,6 +23,7 @@ __all__ = [
 
 def convert_to_bitlinear158(
     module: nn.Module,
+    norm: Optional[Union[str, nn.Module, Callable[[torch.Tensor], torch.Tensor]]] = None,
     dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
@@ -45,6 +47,7 @@ def convert_to_bitlinear158(
     elif isinstance(module, nn.Linear):
         module = convert_linear_to_bitlinear158(
             module,
+            norm=copy.deepcopy(norm),
             dim=dim,
             bits=bits,
             eps=eps,
@@ -53,6 +56,7 @@ def convert_to_bitlinear158(
     elif isinstance(module, nn.MultiheadAttention):
         module = convert_mha_to_bitmha158(
             module,
+            norm=copy.deepcopy(norm),
             dim=dim,
             bits=bits,
             eps=eps,
@@ -65,6 +69,7 @@ def convert_to_bitlinear158(
             elif isinstance(child_module, nn.Linear):
                 converted = convert_linear_to_bitlinear158(
                     child_module,
+                    norm=copy.deepcopy(norm),
                     dim=dim,
                     bits=bits,
                     eps=eps,
@@ -73,6 +78,7 @@ def convert_to_bitlinear158(
             elif isinstance(child_module, nn.MultiheadAttention):
                 converted = convert_mha_to_bitmha158(
                     child_module,
+                    norm=copy.deepcopy(norm),
                     dim=dim,
                     bits=bits,
                     eps=eps,
@@ -81,6 +87,7 @@ def convert_to_bitlinear158(
             else:
                 converted = convert_to_bitlinear158(
                     child_module,
+                    norm=copy.deepcopy(norm),
                     dim=dim,
                     bits=bits,
                     eps=eps,
@@ -94,6 +101,7 @@ def convert_to_bitlinear158(
 
 def convert_to_bitlinear158_inference(
     module: nn.Module,
+    norm: Optional[Union[str, nn.Module, Callable[[torch.Tensor], torch.Tensor]]] = None,
     dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
@@ -117,6 +125,7 @@ def convert_to_bitlinear158_inference(
     """
     module = convert_to_bitlinear158(
         module,
+        norm=copy.deepcopy(norm),
         dim=dim,
         bits=bits,
         eps=eps,
@@ -155,6 +164,7 @@ def convert_to_bitlinear158_inference(
 
 def convert_linear_to_bitlinear158(
     module: nn.Linear,
+    norm: Optional[Union[str, nn.Module, Callable[[torch.Tensor], torch.Tensor]]] = None,
     dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
@@ -178,6 +188,7 @@ def convert_linear_to_bitlinear158(
         in_features,
         out_features,
         bias=bias,
+        norm=copy.deepcopy(norm),
         dim=dim,
         bits=bits,
         eps=eps,
@@ -193,6 +204,7 @@ def convert_linear_to_bitlinear158(
 
 def convert_mha_to_bitmha158(
     module: nn.MultiheadAttention,
+    norm: Optional[Union[str, nn.Module, Callable[[torch.Tensor], torch.Tensor]]] = None,
     dim: Optional[Union[int, Sequence[int]]] = None,
     bits: int = 8,
     eps: float = 1e-5,
@@ -246,6 +258,7 @@ def convert_mha_to_bitmha158(
         kdim=kdim,
         vdim=vdim,
         batch_first=batch_first,
+        norm=copy.deepcopy(norm),
         dim=dim,
         bits=bits,
         eps=eps,

--- a/tests/package/modules/test_bitnet.py
+++ b/tests/package/modules/test_bitnet.py
@@ -17,7 +17,7 @@ def test_bitlinear158(bias: bool) -> None:
     in_features, out_features = 4, 2
     length = 9
 
-    # w/o group_dim
+    # w/o dim
     module = BitLinear158(in_features, out_features, bias=bias)
 
     input = torch.randn((batch_size, length, in_features))
@@ -31,12 +31,12 @@ def test_bitlinear158(bias: bool) -> None:
         if p.requires_grad:
             assert p.grad is not None
 
-    # w/ group_dim: batch-wise scaling
+    # w/ dim: batch-wise scaling
     module = BitLinear158(
         in_features,
         out_features,
         bias=bias,
-        group_dim=(1, -1),
+        dim=(1, -1),
     )
 
     input = torch.randn((batch_size, length, in_features))
@@ -50,12 +50,12 @@ def test_bitlinear158(bias: bool) -> None:
 
     assert torch.allclose(recomputed_output, output)
 
-    # w/ group_dim: batch and token wise scaling
+    # w/ dim: batch and token wise scaling
     module = BitLinear158(
         in_features,
         out_features,
         bias=bias,
-        group_dim=-1,
+        dim=-1,
     )
 
     input = torch.randn((batch_size, length, in_features))
@@ -112,18 +112,18 @@ def test_bitmha158(bias: bool, batch_first: bool) -> None:
         if p.requires_grad:
             assert p.grad is not None
 
-    # w/ group_dim: batch-wise scaling
+    # w/ dim: batch-wise scaling
     if batch_first:
-        group_dim = (1, -1)
+        dim = (1, -1)
     else:
-        group_dim = (0, -1)
+        dim = (0, -1)
 
     module = BitMultiheadAttention158(
         embed_dim,
         num_heads,
         bias=bias,
         batch_first=batch_first,
-        group_dim=group_dim,
+        dim=dim,
     )
     module.eval()
 
@@ -163,13 +163,13 @@ def test_bitmha158(bias: bool, batch_first: bool) -> None:
     assert torch.allclose(recomputed_output, output)
     assert torch.allclose(recomputed_attn_weights, attn_weights)
 
-    # w/ group_dim: batch and token wise scaling
+    # w/ dim: batch and token wise scaling
     module = BitMultiheadAttention158(
         embed_dim,
         num_heads,
         bias=bias,
         batch_first=batch_first,
-        group_dim=-1,
+        dim=-1,
     )
     module.eval()
 
@@ -262,12 +262,12 @@ def test_bitlinear158_inference(bias: bool) -> None:
 
     assert torch.allclose(inference_output, output)
 
-    # w/ group_dim: batch-wise scaling
+    # w/ dim: batch-wise scaling
     module = BitLinear158(
         in_features,
         out_features,
         bias=bias,
-        group_dim=(1, -1),
+        dim=(1, -1),
     )
     module = BitLinear158Inference.build_from_bitlinear158(module)
 
@@ -282,12 +282,12 @@ def test_bitlinear158_inference(bias: bool) -> None:
 
     assert torch.allclose(recomputed_output, output)
 
-    # w/ group_dim: batch and token wise scaling
+    # w/ dim: batch and token wise scaling
     module = BitLinear158(
         in_features,
         out_features,
         bias=bias,
-        group_dim=-1,
+        dim=-1,
     )
     module = BitLinear158Inference.build_from_bitlinear158(module)
 
@@ -340,18 +340,18 @@ def test_bitmha158_inference(bias: bool, batch_first: bool) -> None:
     assert torch.allclose(output, inference_output)
     assert torch.allclose(attn_weights, inference_attn_weights)
 
-    # w/ group_dim: batch-wise scaling
+    # w/ dim: batch-wise scaling
     if batch_first:
-        group_dim = (1, -1)
+        dim = (1, -1)
     else:
-        group_dim = (0, -1)
+        dim = (0, -1)
 
     module = BitMultiheadAttention158(
         embed_dim,
         num_heads,
         bias=bias,
         batch_first=batch_first,
-        group_dim=group_dim,
+        dim=dim,
     )
     module = BitMultiheadAttention158Inference.build_from_bitmha158(module)
     module.eval()
@@ -392,13 +392,13 @@ def test_bitmha158_inference(bias: bool, batch_first: bool) -> None:
     assert torch.allclose(recomputed_output, output)
     assert torch.allclose(recomputed_attn_weights, attn_weights)
 
-    # w/ group_dim: batch and token wise scaling
+    # w/ dim: batch and token wise scaling
     module = BitMultiheadAttention158(
         embed_dim,
         num_heads,
         bias=bias,
         batch_first=batch_first,
-        group_dim=-1,
+        dim=-1,
     )
     module = BitMultiheadAttention158Inference.build_from_bitmha158(module)
     module.eval()

--- a/tests/package/modules/test_bitnet.py
+++ b/tests/package/modules/test_bitnet.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 import torch
 
@@ -10,7 +12,8 @@ from audyn.modules.bitnet import (
 
 
 @pytest.mark.parametrize("bias", [True, False])
-def test_bitlinear158(bias: bool) -> None:
+@pytest.mark.parametrize("norm", [None, "ln", "rms"])
+def test_bitlinear158(bias: bool, norm: Optional[str]) -> None:
     torch.manual_seed(0)
 
     batch_size = 5
@@ -18,7 +21,7 @@ def test_bitlinear158(bias: bool) -> None:
     length = 9
 
     # w/o dim
-    module = BitLinear158(in_features, out_features, bias=bias)
+    module = BitLinear158(in_features, out_features, bias=bias, norm=norm)
 
     input = torch.randn((batch_size, length, in_features))
     output = module(input)
@@ -36,6 +39,7 @@ def test_bitlinear158(bias: bool) -> None:
         in_features,
         out_features,
         bias=bias,
+        norm=norm,
         dim=(1, -1),
     )
 
@@ -55,6 +59,7 @@ def test_bitlinear158(bias: bool) -> None:
         in_features,
         out_features,
         bias=bias,
+        norm=norm,
         dim=-1,
     )
 
@@ -74,7 +79,8 @@ def test_bitlinear158(bias: bool) -> None:
 
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("batch_first", [True, False])
-def test_bitmha158(bias: bool, batch_first: bool) -> None:
+@pytest.mark.parametrize("norm", [None, "ln", "rms"])
+def test_bitmha158(bias: bool, batch_first: bool, norm: Optional[str]) -> None:
     torch.manual_seed(0)
 
     batch_size = 5
@@ -86,6 +92,7 @@ def test_bitmha158(bias: bool, batch_first: bool) -> None:
         num_heads,
         bias=bias,
         batch_first=batch_first,
+        norm=norm,
     )
 
     query = torch.randn((query_length, batch_size, embed_dim))
@@ -123,6 +130,7 @@ def test_bitmha158(bias: bool, batch_first: bool) -> None:
         num_heads,
         bias=bias,
         batch_first=batch_first,
+        norm=norm,
         dim=dim,
     )
     module.eval()
@@ -169,6 +177,7 @@ def test_bitmha158(bias: bool, batch_first: bool) -> None:
         num_heads,
         bias=bias,
         batch_first=batch_first,
+        norm=norm,
         dim=-1,
     )
     module.eval()
@@ -245,14 +254,15 @@ def test_bitmha158(bias: bool, batch_first: bool) -> None:
 
 
 @pytest.mark.parametrize("bias", [True, False])
-def test_bitlinear158_inference(bias: bool) -> None:
+@pytest.mark.parametrize("norm", [None, "ln", "rms"])
+def test_bitlinear158_inference(bias: bool, norm: Optional[str]) -> None:
     torch.manual_seed(0)
 
     batch_size = 5
     in_features, out_features = 4, 2
     length = 9
 
-    module = BitLinear158(in_features, out_features, bias=bias)
+    module = BitLinear158(in_features, out_features, bias=bias, norm=norm)
 
     input = torch.randn((batch_size, length, in_features))
     output = module(input)
@@ -267,6 +277,7 @@ def test_bitlinear158_inference(bias: bool) -> None:
         in_features,
         out_features,
         bias=bias,
+        norm=norm,
         dim=(1, -1),
     )
     module = BitLinear158Inference.build_from_bitlinear158(module)
@@ -287,6 +298,7 @@ def test_bitlinear158_inference(bias: bool) -> None:
         in_features,
         out_features,
         bias=bias,
+        norm=norm,
         dim=-1,
     )
     module = BitLinear158Inference.build_from_bitlinear158(module)
@@ -307,7 +319,8 @@ def test_bitlinear158_inference(bias: bool) -> None:
 
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("batch_first", [True, False])
-def test_bitmha158_inference(bias: bool, batch_first: bool) -> None:
+@pytest.mark.parametrize("norm", [None, "ln", "rms"])
+def test_bitmha158_inference(bias: bool, batch_first: bool, norm: Optional[str]) -> None:
     torch.manual_seed(0)
 
     batch_size = 5
@@ -319,6 +332,7 @@ def test_bitmha158_inference(bias: bool, batch_first: bool) -> None:
         num_heads,
         bias=bias,
         batch_first=batch_first,
+        norm=norm,
     )
     module.eval()
 
@@ -351,6 +365,7 @@ def test_bitmha158_inference(bias: bool, batch_first: bool) -> None:
         num_heads,
         bias=bias,
         batch_first=batch_first,
+        norm=norm,
         dim=dim,
     )
     module = BitMultiheadAttention158Inference.build_from_bitmha158(module)
@@ -398,6 +413,7 @@ def test_bitmha158_inference(bias: bool, batch_first: bool) -> None:
         num_heads,
         bias=bias,
         batch_first=batch_first,
+        norm=norm,
         dim=-1,
     )
     module = BitMultiheadAttention158Inference.build_from_bitmha158(module)


### PR DESCRIPTION
## Summary
By this PR, `BitLinear` and `BitMultiheadAttention` start to support layer normalizations.