### PR TITLE
Bump up version to 0.0.1

### DIFF
--- a/audyn/__init__.py
+++ b/audyn/__init__.py
@@ -9,7 +9,7 @@ from .utils.hydra import main
 
 __all__ = ["__version__", "main"]
 
-__version__ = "0.0.1.dev8"
+__version__ = "0.0.1"
 
 # for resolver
 _whitespace_re = re.compile(r"\s+")


### PR DESCRIPTION
## Summary
This PR bumps up the version of `Audyn` to `0.0.1`.