### PR TITLE
Rename AST and SSAST built by `build_from_pretrained_config`

### DIFF
--- a/audyn/models/ast.py
+++ b/audyn/models/ast.py
@@ -366,6 +366,7 @@ class AudioSpectrogramTransformer(BaseAudioSpectrogramTransformer):
             resolved_config = state_dict["resolved_config"]
             resolved_config = OmegaConf.create(resolved_config)
             pretrained_model_config = resolved_config.model
+            pretrained_model_config["_target_"] = f"{cls.__module__}.{cls.__name__}"
             model: AudioSpectrogramTransformer = instantiate(pretrained_model_config)
             model.load_state_dict(model_state_dict)
 

--- a/audyn/models/ssast.py
+++ b/audyn/models/ssast.py
@@ -354,9 +354,11 @@ class MultiTaskSelfSupervisedAudioSpectrogramTransformerMaskedPatchModel(
             )
             resolved_config = state_dict["resolved_config"]
             resolved_config = OmegaConf.create(resolved_config)
+            pretrained_model_config = resolved_config.model
+            pretrained_model_config["_target_"] = f"{cls.__module__}.{cls.__name__}"
 
             model: MultiTaskSelfSupervisedAudioSpectrogramTransformerMaskedPatchModel = (
-                instantiate(resolved_config.model)
+                instantiate(pretrained_model_config)
             )
             model.load_state_dict(state_dict["model"])
 

--- a/tests/package/models/test_ast.py
+++ b/tests/package/models/test_ast.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 from dummy import allclose
 
 from audyn.models.ast import (
+    AST,
     AudioSpectrogramTransformer,
     AverageAggregator,
     HeadTokensAggregator,
@@ -93,6 +94,26 @@ def test_official_ast() -> None:
             num_parameters += p.numel()
 
     assert num_parameters == expected_num_parameters
+    assert model.__class__.__name__ == "AudioSpectrogramTransformer"
+
+    # build_from_pretrained
+    model = AST.build_from_pretrained(
+        "ast-base-stride10",
+        stride=stride,
+        n_bins=n_bins,
+        n_frames=n_frames,
+        aggregator=aggregator,
+        head=head,
+    )
+
+    num_parameters = 0
+
+    for p in model.parameters():
+        if p.requires_grad:
+            num_parameters += p.numel()
+
+    assert num_parameters == expected_num_parameters
+    assert model.__class__.__name__ == "AST"
 
     # regression test
     n_bins, n_frames = 256, 100

--- a/tests/package/models/test_ssast.py
+++ b/tests/package/models/test_ssast.py
@@ -11,9 +11,11 @@ from audyn.models.lextransformer import LEXTransformerEncoderLayer
 from audyn.models.roformer import RoFormerEncoderLayer
 from audyn.models.ssast import (
     MLP,
+    SSAST,
     FastMasker,
     Masker,
     MultiTaskSelfSupervisedAudioSpectrogramTransformerMaskedPatchModel,
+    MultiTaskSSASTMPM,
     SelfSupervisedAudioSpectrogramTransformer,
 )
 from audyn.modules.vit import PatchEmbedding, PositionalPatchEmbedding
@@ -112,6 +114,21 @@ def test_official_ssast_multi_task_mpm(model_name: str, sample_wise: bool) -> No
             num_parameters += p.numel()
 
     assert num_parameters == expected_num_parameters
+    assert (
+        model.__class__.__name__
+        == "MultiTaskSelfSupervisedAudioSpectrogramTransformerMaskedPatchModel"
+    )
+
+    model = MultiTaskSSASTMPM.build_from_pretrained(model_name)
+
+    num_parameters = 0
+
+    for p in model.parameters():
+        if p.requires_grad:
+            num_parameters += p.numel()
+
+    assert num_parameters == expected_num_parameters
+    assert model.__class__.__name__ == "MultiTaskSSASTMPM"
 
 
 @pytest.mark.parametrize(
@@ -196,6 +213,20 @@ def test_official_ssast(model_name: str) -> None:
             num_parameters += p.numel()
 
     assert num_parameters == expected_num_parameters
+    assert model.__class__.__name__ == "SelfSupervisedAudioSpectrogramTransformer"
+
+    model = SSAST.build_from_pretrained(
+        model_name, stride=stride, n_bins=n_bins, n_frames=n_frames, head=head
+    )
+
+    num_parameters = 0
+
+    for p in model.parameters():
+        if p.requires_grad:
+            num_parameters += p.numel()
+
+    assert num_parameters == expected_num_parameters
+    assert model.__class__.__name__ == "SSAST"
 
     # regression test
     n_bins, n_frames = 256, 100


### PR DESCRIPTION
## Summary
This PR fixes names of AST and SSAST built by build_from_pretrained_config.