### PR TITLE
Set version to 0.0.6.dev0

### DIFF
--- a/audyn/__init__.py
+++ b/audyn/__init__.py
@@ -11,7 +11,7 @@ from .utils._hydra import main
 
 __all__ = ["__version__", "main"]
 
-__version__ = "0.0.5"
+__version__ = "0.0.6.dev0"
 
 IS_WINDOWS = sys.platform == "win32"
 


### PR DESCRIPTION
## Summary
For development, this PR sets version of `Audyn` to `0.0.6.dev0`.