### PR TITLE
Support annotation by `audyn-download-mtat`

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -52,6 +52,26 @@ You can download audio files of MTG-Jamendo dataset by ``audyn-download-mtg-jame
     unpack=${unpack} \
     chunk_size=${chunk_size}
 
+
+Download MagnaTagATune (MTAT) dataset
+-------------------------------------
+
+You can download audio files of MTAT dataset by ``audyn-download-mtat``.
+
+.. code-block:: shell
+
+    data_root="./data"  # root directory to save .zip file.
+    mtat_root="${data_root}/MTAT"
+    unpack=true  # unpack .zip or not
+    chunk_size=8192  # chunk size in byte to download
+
+    audyn-download-mtat \
+    root="${data_root}" \
+    mtat_root="${mtat_root}" \
+    unpack=${unpack} \
+    chunk_size=${chunk_size}
+
+
 Download OpenMIC-2018
 ---------------------
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -72,8 +72,8 @@ You can download audio files of MTAT dataset by ``audyn-download-mtat``.
     chunk_size=${chunk_size}
 
 
-Download OpenMIC-2018
----------------------
+Download OpenMIC-2018 dataset
+-----------------------------
 
 You can download OpenMIC-2018 dataset by ``audyn-download-openmic2018``.
 
@@ -88,4 +88,20 @@ You can download OpenMIC-2018 dataset by ``audyn-download-openmic2018``.
     root="${data_root}" \
     openmic2018_root="${openmic2018_root}" \
     unpack=${unpack} \
+    chunk_size=${chunk_size}
+
+
+Download SingMOS dataset
+------------------------
+
+You can download SingMOS dataset by ``audyn-download-singmos``.
+
+.. code-block:: shell
+
+    data_root="./data"
+    singmos_root="${data_root}/SingMOS"
+    chunk_size=8192  # chunk size in byte to download
+
+    audyn-download-singmos \
+    singmos_root="${singmos_root}" \
     chunk_size=${chunk_size}


### PR DESCRIPTION
## Summary
In this PR
- Annotations of MTAT dataset are downloaded by `audyn-download-mtat`.
- Description of `audyn-download-mtat` is added to docs.